### PR TITLE
fsthttp: add Adapt method for using http.Handlers

### DIFF
--- a/fsthttp/adapter.go
+++ b/fsthttp/adapter.go
@@ -1,0 +1,67 @@
+package fsthttp
+
+import (
+	"context"
+	"net/http"
+)
+
+// responseWriterAdapter is an implementation of http.ResponseWriter on
+// top of fsthttp.ResponseWriter.  It is necessary because the Header
+// types are different, despite being otherwise compatible.
+type responseWriterAdapter struct {
+	w ResponseWriter
+}
+
+func (w *responseWriterAdapter) Header() http.Header {
+	return http.Header(w.w.Header())
+}
+
+func (w *responseWriterAdapter) Write(b []byte) (int, error) {
+	return w.w.Write(b)
+}
+
+func (w *responseWriterAdapter) WriteHeader(status int) {
+	w.w.WriteHeader(status)
+}
+
+// Adapt allows an http.Handler to be used as an fsthttp.Handler.
+//
+// Because the Request and ResponseWriter types are not exactly the same
+// as ones in net/http, helper accessor functions exist to extract the
+// fsthttp values from the request context.
+func Adapt(h http.Handler) Handler {
+	return HandlerFunc(func(ctx context.Context, w ResponseWriter, r *Request) {
+		ctx = contextWithRequest(ctx, r)
+		ctx = contextWithResponseWriter(ctx, w)
+
+		hw := &responseWriterAdapter{w: w}
+
+		hr, err := http.NewRequestWithContext(ctx, r.Method, r.URL.String(), r.Body)
+		if err != nil {
+			w.WriteHeader(StatusInternalServerError)
+			return
+		}
+		hr.Proto = r.Proto
+		hr.ProtoMajor = r.ProtoMajor
+		hr.ProtoMinor = r.ProtoMinor
+		hr.Header = http.Header(r.Header.Clone())
+		hr.Host = r.Host
+		hr.RemoteAddr = r.RemoteAddr
+		hr.ContentLength = -1
+
+		// TODO: Translate some of fsthttp.TLSInfo into
+		// tls.ConnectionState.
+		//
+		// The protocol version and chosen cipher are available but
+		// provided via the ABI as strings, which we would need to
+		// convert back into integer values.
+		//
+		// The raw ClientHello is provided, so we could use
+		// golang.org/x/crypto/cryptobyte to parse it.  But
+		// server-chosen properties of the connection (cipher, ALPN,
+		// client certificate, etc.) would need to be provided by the
+		// ABI.
+
+		h.ServeHTTP(hw, hr)
+	})
+}

--- a/fsthttp/adapter_test.go
+++ b/fsthttp/adapter_test.go
@@ -1,0 +1,80 @@
+package fsthttp
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+// A poor replacement for httptest.ResponseRecorder
+type ResponseRecorder struct {
+	Code      int
+	HeaderMap Header
+	Body      *bytes.Buffer
+}
+
+func NewRecorder() *ResponseRecorder {
+	return &ResponseRecorder{
+		Code:      StatusOK,
+		HeaderMap: make(Header),
+		Body:      &bytes.Buffer{},
+	}
+}
+
+func (r *ResponseRecorder) Header() Header {
+	return r.HeaderMap
+}
+
+func (r *ResponseRecorder) WriteHeader(code int) {
+	r.Code = code
+}
+
+func (r *ResponseRecorder) Write(b []byte) (int, error) {
+	return r.Body.Write(b)
+}
+
+func (r *ResponseRecorder) Close() error {
+	return nil
+}
+
+func (r *ResponseRecorder) SetManualFramingMode(v bool) {}
+
+func TestAdapter(t *testing.T) {
+	t.Parallel()
+
+	hh := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fr := RequestFromContext(r.Context())
+		if fr == nil {
+			http.Error(w, "no fsthttp.Request in context", http.StatusInternalServerError)
+			return
+		}
+
+		fw := ResponseWriterFromContext(r.Context())
+		if fw == nil {
+			http.Error(w, "no fsthttp.ResponseWriter in context", http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusTeapot)
+		fmt.Fprintln(w, "Hello, client")
+	})
+
+	r, err := NewRequest(http.MethodGet, "http://example.com", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	w := NewRecorder()
+
+	Adapt(hh).ServeHTTP(context.Background(), w, r)
+
+	if want, got := StatusTeapot, w.Code; want != got {
+		t.Errorf("want code %d, got %d", want, got)
+	}
+
+	if want, got := "Hello, client\n", w.Body.String(); want != got {
+		t.Errorf("want body %q, got %q", want, got)
+	}
+}

--- a/fsthttp/context.go
+++ b/fsthttp/context.go
@@ -1,0 +1,30 @@
+package fsthttp
+
+import "context"
+
+type (
+	requestContextKey        struct{}
+	responseWriterContextKey struct{}
+)
+
+// RequestFromContext returns the fsthttp.Request associated with the
+// context, if any.
+func RequestFromContext(ctx context.Context) *Request {
+	req, _ := ctx.Value(requestContextKey{}).(*Request)
+	return req
+}
+
+func contextWithRequest(ctx context.Context, req *Request) context.Context {
+	return context.WithValue(ctx, requestContextKey{}, req)
+}
+
+// ResponseWriterFromContext returns the fsthttp.ResponseWriter associated
+// with the context, if any.
+func ResponseWriterFromContext(ctx context.Context) ResponseWriter {
+	w, _ := ctx.Value(responseWriterContextKey{}).(ResponseWriter)
+	return w
+}
+
+func contextWithResponseWriter(ctx context.Context, w ResponseWriter) context.Context {
+	return context.WithValue(ctx, responseWriterContextKey{}, w)
+}


### PR DESCRIPTION
This introduces a new `fsthttp.Adapt` function, which converts an `http.Handler` into an `fsthttp.Handler` for use with the
`fsthttp.Serve` function.  This lets us bridge existing code that uses `http.Handler` into the C@E environment.

Any existing `http.Handler` should work and it has been tested with `http.ServeMux`, `gorilla/mux`, and `chi`.  Note, however, that not all fields of the `http.Request` are populated.

The `fsthttp.Request` and `fsthttp.ResponseWriter` types are not exactly the same as their `net/http` counterparts.  In order to make the original `fsthttp` types available inside handlers, new `fsthttp.RequestFromContext` and `fsthttp.ResponseWriterFromContext` functions are provided and can be called on the `http.Request`'s `Context()` method.

Example usage:
```go
func main() {
    mux := http.NewServeMux()
    mux.HandleFunc("/hello", func(w http.ResponseWriter, r *http.Request) {
        fr := fsthttp.RequestFromContext(r.Context())
        fmt.Fprintf(w, "TLS cipher: %s\n", fr.TLSInfo.CipherOpenSSLName)
    })

    fsthttp.Serve(fsthttp.Adapt(mux))
}
```
