### PR TITLE
add fsthttp.Transport, which is an http.RoundTripper implementation

### DIFF
--- a/fsthttp/context.go
+++ b/fsthttp/context.go
@@ -5,6 +5,7 @@ import "context"
 type (
 	requestContextKey        struct{}
 	responseWriterContextKey struct{}
+	responseContextKey       struct{}
 )
 
 // RequestFromContext returns the fsthttp.Request associated with the
@@ -27,4 +28,15 @@ func ResponseWriterFromContext(ctx context.Context) ResponseWriter {
 
 func contextWithResponseWriter(ctx context.Context, w ResponseWriter) context.Context {
 	return context.WithValue(ctx, responseWriterContextKey{}, w)
+}
+
+// ResponseFromContext returns the fsthttp.Response associated with the
+// context, if any.
+func ResponseFromContext(ctx context.Context) *Response {
+	resp, _ := ctx.Value(responseContextKey{}).(*Response)
+	return resp
+}
+
+func contextWithResponse(ctx context.Context, resp *Response) context.Context {
+	return context.WithValue(ctx, responseContextKey{}, resp)
 }

--- a/fsthttp/transport.go
+++ b/fsthttp/transport.go
@@ -1,0 +1,92 @@
+package fsthttp
+
+import (
+	"net/http"
+	"strings"
+)
+
+// Transport is an http.RoundTripper implementation for backend requests
+// on Compute@Edge.
+//
+// Compute@Edge requests must be made to a pre-configured named backend.
+// A default backend is set when the transport is created, but
+// additional backends can be added with the AddBackend method.
+//
+// This is primarily intended to adapt existing code which uses
+// configurable http.Client instances to work on Compute@Edge.  Using an
+// http.Client pulls in substantially more code, resulting in slower
+// compile times and larger binaries.  For this reason, we recommend new
+// code use the fsthttp.Request type and its Send() method directly
+// whenever possible.
+type Transport struct {
+	defaultBackend string
+	backends       map[string]string
+
+	// Request is an optional callback invoked before the request is
+	// sent to the backend.  It allows callers to set
+	// fsthttp.Request-specific fields, such as cache control options.
+	Request func(req *Request) error
+}
+
+// NewTransport creates a new Transport instance with the given default
+// backend.
+func NewTransport(backend string) *Transport {
+	return &Transport{
+		defaultBackend: backend,
+		backends:       make(map[string]string),
+	}
+}
+
+// AddBackend adds a new backend to the transport.
+func (t *Transport) AddBackend(name, host string) {
+	t.backends[strings.ToLower(host)] = name
+}
+
+func (t *Transport) getBackend(host string) string {
+	if backend, ok := t.backends[strings.ToLower(host)]; ok {
+		return backend
+	}
+	return t.defaultBackend
+}
+
+// RoundTrip implements the http.RoundTripper interface.
+//
+// The provided http.Request is adapted into an fsthttp.Request. If the
+// Transport's Request callback field is set, it is invoked so that the
+// fsthttp.Request can be modified before it is sent.  The request is
+// then sent to the backend matching the host in the URL.  The resulting
+// fsthttp.Response is adapted into an http.Response and returned.
+//
+// The http.Response's Request field contains a context from which the
+// original fsthttp.Request and fsthttp.Response can be extracted using
+// fsthttp.RequestFromContext and fsthttp.ResponseFromContext.
+func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	freq, err := NewRequest(req.Method, req.URL.String(), req.Body)
+	if err != nil {
+		return nil, err
+	}
+	freq.Header = Header(req.Header.Clone())
+
+	if t.Request != nil {
+		if err := t.Request(freq); err != nil {
+			return nil, err
+		}
+	}
+
+	fresp, err := freq.Send(req.Context(), t.getBackend(req.URL.Host))
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := contextWithRequest(req.Context(), freq)
+	ctx = contextWithResponse(ctx, fresp)
+
+	resp := &http.Response{
+		Request:    req.WithContext(ctx),
+		StatusCode: fresp.StatusCode,
+		Header:     http.Header(fresp.Header.Clone()),
+		Body:       fresp.Body,
+	}
+
+	return resp, nil
+}

--- a/fsthttp/transport.go
+++ b/fsthttp/transport.go
@@ -9,15 +9,17 @@ import (
 // on Compute@Edge.
 //
 // Compute@Edge requests must be made to a pre-configured named backend.
-// A default backend is set when the transport is created, but
-// additional backends can be added with the AddBackend method.
+// Transport provides a mechanism for mapping hostnames to backend
+// names.  A default catchall backend is set when the Transport is
+// created, but additional host-to-backend mappings can be added with
+// the AddHostBackend method.
 //
-// This is primarily intended to adapt existing code which uses
-// configurable http.Client instances to work on Compute@Edge.  Using an
-// http.Client pulls in substantially more code, resulting in slower
-// compile times and larger binaries.  For this reason, we recommend new
-// code use the fsthttp.Request type and its Send() method directly
-// whenever possible.
+// Transport is provided primarily to adapt existing code which uses
+// http.Client instances to work on Compute@Edge.  Using an http.Client
+// pulls in substantially more code, resulting in slower compile times
+// and larger binaries.  For this reason, we recommend new code use the
+// fsthttp.Request type and its Send() method directly whenever
+// possible.
 type Transport struct {
 	defaultBackend string
 	backends       map[string]string
@@ -29,6 +31,8 @@ type Transport struct {
 }
 
 // NewTransport creates a new Transport instance with the given default
+// backend.  Any request made to a host not explicitly mapped to a
+// backend using the AddHostBackend method will be sent to the default
 // backend.
 func NewTransport(backend string) *Transport {
 	return &Transport{
@@ -37,9 +41,10 @@ func NewTransport(backend string) *Transport {
 	}
 }
 
-// AddBackend adds a new backend to the transport.
-func (t *Transport) AddBackend(name, host string) {
-	t.backends[strings.ToLower(host)] = name
+// AddHostBackend adds a new host-to-backend mapping.  Multiple hosts
+// may be mapped to the same backend.
+func (t *Transport) AddHostBackend(host, backend string) {
+	t.backends[strings.ToLower(host)] = backend
 }
 
 func (t *Transport) getBackend(host string) string {


### PR DESCRIPTION
This allows existing Go code which uses an http.Client to be adapted to
work on Compute@Edge.

This is intended only to adapt existing code.  Using http.Client pulls
in substantially more code than is needed for a simple request,
resulting in slower compile times and larger binaries.  We recommend new
code use the fsthttp.Request type and its Send() method directly
whenever possible.
