### PR TITLE
add Secret Store implementation

### DIFF
--- a/.github/actions/bootstrap-integration-test/action.yml
+++ b/.github/actions/bootstrap-integration-test/action.yml
@@ -4,21 +4,21 @@ runs:
   using: "composite"
   steps:
     - run: |
-        echo "Install Fastly CLI 3.0.0"
-        wget https://github.com/fastly/cli/releases/download/v3.0.0/fastly_3.0.0_linux_amd64.deb
-        sudo apt install ./fastly_3.0.0_linux_amd64.deb
+        echo "Install Fastly CLI 5.0.0"
+        wget https://github.com/fastly/cli/releases/download/v5.0.0/fastly_5.0.0_linux_amd64.deb
+        sudo apt install ./fastly_5.0.0_linux_amd64.deb
       shell: "bash"
     - run: |
-        echo "Install Viceroy 0.2.14..."
-        wget https://github.com/fastly/Viceroy/releases/download/v0.2.14/viceroy_v0.2.14_linux-amd64.tar.gz
+        echo "Install Viceroy 0.3.5..."
+        wget https://github.com/fastly/Viceroy/releases/download/v0.3.5/viceroy_v0.3.5_linux-amd64.tar.gz
         mkdir -p $HOME/bin
-        tar -xzf viceroy_v0.2.14_linux-amd64.tar.gz --directory $HOME/bin
+        tar -xzf viceroy_v0.3.5_linux-amd64.tar.gz --directory $HOME/bin
         echo "$HOME/bin" >> $GITHUB_PATH
       shell: "bash"
     - run: |
-        echo "Install TinyGo 0.24.0..."
-        wget https://github.com/tinygo-org/tinygo/releases/download/v0.24.0/tinygo_0.24.0_amd64.deb
-        echo "f9366fafa4b281a6874f17017053f9223a2222521c2084f50cc323a976f8f34848a13a31b4d60ddd24a3ab04d56ae5fd8c9445aa2b42245bbb3037c894452ae1 tinygo_0.24.0_amd64.deb" | sha512sum --check
-        sudo dpkg -i tinygo_0.24.0_amd64.deb
+        echo "Install TinyGo 0.26.0..."
+        wget https://github.com/tinygo-org/tinygo/releases/download/v0.26.0/tinygo_0.26.0_amd64.deb
+        echo "dd7d47bc15be3690932394faca93ac6433a309cbe2957fc71e5688e567cd6d1ce0b8bf1e92455058e4547db6a70e176af85fe1b507537966a160bf88a819a101 tinygo_0.26.0_amd64.deb" | sha512sum --check
+        sudo dpkg -i tinygo_0.26.0_amd64.deb
         echo "/usr/local/tinygo/bin" >> $GITHUB_PATH
       shell: "bash"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-         go-version: '1.18' 
+         go-version: '1.19' 
       - name: compute-sdk-go Integration Tests Job
         uses: ./.github/actions/compute-sdk-test
         id: sdktest
@@ -42,7 +42,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17' 
+          go-version: '1.18' 
       - name: compute-sdk-go Integration Tests Job
         uses: ./.github/actions/compute-sdk-test
         id: sdktest

--- a/_examples/secret-store/main.go
+++ b/_examples/secret-store/main.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/fastly/compute-sdk-go/fsthttp"
+	"github.com/fastly/compute-sdk-go/secretstore"
+)
+
+func main() {
+	fsthttp.ServeFunc(func(ctx context.Context, w fsthttp.ResponseWriter, r *fsthttp.Request) {
+		st, err := secretstore.Open("example_secretstore")
+		switch {
+		case errors.Is(err, secretstore.ErrSecretStoreNotFound):
+			fsthttp.Error(w, err.Error(), fsthttp.StatusNotFound)
+			return
+		case err != nil:
+			fsthttp.Error(w, err.Error(), fsthttp.StatusBadGateway)
+			return
+		}
+
+		s, err := st.Get("my_secret")
+		switch {
+		case errors.Is(err, secretstore.ErrSecretNotFound):
+			fsthttp.Error(w, err.Error(), fsthttp.StatusNotFound)
+			return
+		case err != nil:
+			fsthttp.Error(w, err.Error(), fsthttp.StatusBadGateway)
+			return
+		}
+
+		v, err := s.Plaintext()
+		if err != nil {
+			fsthttp.Error(w, err.Error(), fsthttp.StatusBadGateway)
+			return
+		}
+
+		fmt.Fprintf(w, "secret value: %q", v)
+	})
+}

--- a/_integration_tests/fixtures/secret_store/fastly.toml
+++ b/_integration_tests/fixtures/secret_store/fastly.toml
@@ -1,0 +1,12 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "secret_store"
+service_id = ""
+
+[local_server]
+  secret_store.phrases = [{key = "my_phrase", data = "sssh! don't tell anyone!"}]

--- a/_integration_tests/fixtures/secret_store/main.go
+++ b/_integration_tests/fixtures/secret_store/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/fastly/compute-sdk-go/fsthttp"
+	"github.com/fastly/compute-sdk-go/secretstore"
+)
+
+func main() {
+	fsthttp.ServeFunc(func(ctx context.Context, w fsthttp.ResponseWriter, r *fsthttp.Request) {
+		st, err := secretstore.Open("phrases")
+		switch {
+		case errors.Is(err, secretstore.ErrSecretStoreNotFound):
+			fsthttp.Error(w, err.Error(), fsthttp.StatusNotFound)
+			return
+		case err != nil:
+			fsthttp.Error(w, err.Error(), fsthttp.StatusInternalServerError)
+			return
+		}
+
+		s, err := st.Get("my_phrase")
+		switch {
+		case errors.Is(err, secretstore.ErrSecretNotFound):
+			fsthttp.Error(w, err.Error(), fsthttp.StatusNotFound)
+			return
+		case err != nil:
+			fsthttp.Error(w, err.Error(), fsthttp.StatusInternalServerError)
+			return
+		}
+
+		v, err := s.Plaintext()
+		if err != nil {
+			fsthttp.Error(w, err.Error(), fsthttp.StatusInternalServerError)
+			return
+		}
+
+		w.Write(v)
+	})
+}

--- a/_integration_tests/sdk-test-config.json
+++ b/_integration_tests/sdk-test-config.json
@@ -218,6 +218,27 @@
           ]
         }
       }
+    },
+
+    "secret_store" : {
+      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -wasm-abi=generic -o ./_integration_tests/fixtures/secret_store/secret_store.wasm ./_integration_tests/fixtures/secret_store && (cd ./_integration_tests/fixtures/secret_store && fastly compute pack --verbose --wasm-binary ./secret_store.wasm)",
+      "fastly_toml_path": "./_integration_tests/fixtures/secret_store/fastly.toml",
+      "wasm_path": "./_integration_tests/fixtures/secret_store/secret_store.wasm",
+      "pkg_path": "./_integration_tests/fixtures/secret_store/pkg/secret-store.tar.gz",
+      "tests": {
+        "POST /": {
+          "environments": ["viceroy"],
+          "downstream_request": {
+            "method": "GET",
+            "pathname": "/"
+          },
+          "downstream_response": {
+            "status": 200,
+            "body": "sssh! don't tell anyone!"
+          }
+        }
+      }
     }
+
   }
 }

--- a/internal/abi/fastly/hostcalls_noguest.go
+++ b/internal/abi/fastly/hostcalls_noguest.go
@@ -258,3 +258,20 @@ func (o *ObjectStore) Lookup(key string) (io.Reader, error) {
 func (o *ObjectStore) Insert(key string, value io.Reader) error {
 	return fmt.Errorf("not implemented")
 }
+
+type (
+	SecretStore struct{}
+	Secret      struct{}
+)
+
+func OpenSecretStore(name string) (*SecretStore, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *SecretStore) Get(name string) (*Secret, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (s *Secret) Plaintext() ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}

--- a/internal/abi/fastly/types.go
+++ b/internal/abi/fastly/types.go
@@ -290,6 +290,8 @@ var (
 	MaxMethodLen = 1024
 	// MaxURLLen is the url limit
 	MaxURLLen = 1024
+	// InitialSecretLen is the initial size of the buffer to use for decrypting secrets
+	InitialSecretLen = 1024
 )
 
 const (
@@ -470,3 +472,10 @@ const (
 //
 //	(typename $object_store_handle (handle))
 type objectStoreHandle handle
+
+// witx:
+//
+//	(typename $secret_store_handle (handle))
+//	(typename $secret_handle (handle))
+type secretStoreHandle handle
+type secretHandle handle

--- a/secretstore/secretstore.go
+++ b/secretstore/secretstore.go
@@ -1,0 +1,62 @@
+package secretstore
+
+import (
+	"errors"
+
+	"github.com/fastly/compute-sdk-go/internal/abi/fastly"
+)
+
+var (
+	// ErrSecretStoreNotFound indicates that the named secret store
+	// doesn't exist.
+	ErrSecretStoreNotFound = errors.New("secret store not found")
+
+	// ErrSecretNotFound indicates that the named secret doesn't exist
+	// within this store.
+	ErrSecretNotFound = errors.New("secret not found")
+)
+
+// Store represents a Fastly Secret Store
+type Store struct {
+	st *fastly.SecretStore
+}
+
+// Secret represents a secret in a store
+type Secret struct {
+	s *fastly.Secret
+}
+
+// Open returns a handle to the named secret store, if it exists.  It
+// will return [ErrSecretStoreNotFound] if it doesn't exist.
+func Open(name string) (*Store, error) {
+	st, err := fastly.OpenSecretStore(name)
+	if err != nil {
+		status, ok := fastly.IsFastlyError(err)
+		if ok && status == fastly.FastlyStatusNone {
+			return nil, ErrSecretStoreNotFound
+		}
+		return nil, err
+	}
+
+	return &Store{st: st}, nil
+}
+
+// Get returns a handle to the named secret within the store, if it
+// exists.  It will return [ErrSecretNotFound] if it doesn't exist.
+func (st *Store) Get(name string) (*Secret, error) {
+	s, err := st.st.Get(name)
+	if err != nil {
+		status, ok := fastly.IsFastlyError(err)
+		if ok && status == fastly.FastlyStatusNone {
+			return nil, ErrSecretNotFound
+		}
+		return nil, err
+	}
+
+	return &Secret{s: s}, nil
+}
+
+// Plaintext decrypts and returns the secret value as a byte slice.
+func (s *Secret) Plaintext() ([]byte, error) {
+	return s.s.Plaintext()
+}


### PR DESCRIPTION
This adds hostcall and SDK support for the Fastly Secret Store.  An
example is included for usage but the basic idea is:

```go
st, err := secretstore.Open("example_secretstore")
if err != nil {
    panic(err)
}

s, err := st.Get("my_secret")
if err != nil {
    panic(err)
}

pt, err := s.Plaintext()
if err != nil {
    panic(err)
}

fmt.Fprintf(w, "secret value: %q", v)
```
