### PR TITLE
lint: use nilness from master

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,7 +16,7 @@ jobs:
           staticcheck ./...
       - name: nilness
         run: |
-          go install golang.org/x/tools/go/analysis/passes/nilness/cmd/nilness@latest
+          go install golang.org/x/tools/go/analysis/passes/nilness/cmd/nilness@master
           nilness ./...
       - name: ineffassign
         run: |


### PR DESCRIPTION
The latest release of nilness panics when used with Go 1.20.  See
golang/go#58296.  This was fixed, but hasn't been released yet, which
is why we pull from master.
