### PR TITLE
Update CI tooling

### DIFF
--- a/.github/actions/bootstrap-integration-test/action.yml
+++ b/.github/actions/bootstrap-integration-test/action.yml
@@ -15,10 +15,3 @@ runs:
         tar -xzf viceroy_v0.4.0_linux-amd64.tar.gz --directory $HOME/bin
         echo "$HOME/bin" >> $GITHUB_PATH
       shell: "bash"
-    - run: |
-        echo "Install TinyGo 0.27.0..."
-        wget https://github.com/tinygo-org/tinygo/releases/download/v0.27.0/tinygo_0.27.0_amd64.deb
-        echo "030336ec61c87083b1a933bea2bc3a139e2921f4317945fc03eea965d3963a72b28d9592dfb40e64df2620e9010caadda08205c85a98f76c49bcd1569fe8ddc3 tinygo_0.27.0_amd64.deb" | sha512sum --check
-        sudo dpkg -i tinygo_0.27.0_amd64.deb
-        echo "/usr/local/tinygo/bin" >> $GITHUB_PATH
-      shell: "bash"

--- a/.github/actions/bootstrap-integration-test/action.yml
+++ b/.github/actions/bootstrap-integration-test/action.yml
@@ -4,21 +4,21 @@ runs:
   using: "composite"
   steps:
     - run: |
-        echo "Install Fastly CLI 5.0.0"
-        wget https://github.com/fastly/cli/releases/download/v5.0.0/fastly_5.0.0_linux_amd64.deb
-        sudo apt install ./fastly_5.0.0_linux_amd64.deb
+        echo "Install Fastly CLI 8.1.2"
+        wget https://github.com/fastly/cli/releases/download/v8.1.2/fastly_8.1.2_linux_amd64.deb
+        sudo apt install ./fastly_8.1.2_linux_amd64.deb
       shell: "bash"
     - run: |
-        echo "Install Viceroy 0.3.5..."
-        wget https://github.com/fastly/Viceroy/releases/download/v0.3.5/viceroy_v0.3.5_linux-amd64.tar.gz
+        echo "Install Viceroy 0.4.0..."
+        wget https://github.com/fastly/Viceroy/releases/download/v0.4.0/viceroy_v0.4.0_linux-amd64.tar.gz
         mkdir -p $HOME/bin
-        tar -xzf viceroy_v0.3.5_linux-amd64.tar.gz --directory $HOME/bin
+        tar -xzf viceroy_v0.4.0_linux-amd64.tar.gz --directory $HOME/bin
         echo "$HOME/bin" >> $GITHUB_PATH
       shell: "bash"
     - run: |
-        echo "Install TinyGo 0.26.0..."
-        wget https://github.com/tinygo-org/tinygo/releases/download/v0.26.0/tinygo_0.26.0_amd64.deb
-        echo "dd7d47bc15be3690932394faca93ac6433a309cbe2957fc71e5688e567cd6d1ce0b8bf1e92455058e4547db6a70e176af85fe1b507537966a160bf88a819a101 tinygo_0.26.0_amd64.deb" | sha512sum --check
-        sudo dpkg -i tinygo_0.26.0_amd64.deb
+        echo "Install TinyGo 0.27.0..."
+        wget https://github.com/tinygo-org/tinygo/releases/download/v0.27.0/tinygo_0.27.0_amd64.deb
+        echo "030336ec61c87083b1a933bea2bc3a139e2921f4317945fc03eea965d3963a72b28d9592dfb40e64df2620e9010caadda08205c85a98f76c49bcd1569fe8ddc3 tinygo_0.27.0_amd64.deb" | sha512sum --check
+        sudo dpkg -i tinygo_0.27.0_amd64.deb
         echo "/usr/local/tinygo/bin" >> $GITHUB_PATH
       shell: "bash"

--- a/.github/actions/install-tinygo/action.yml
+++ b/.github/actions/install-tinygo/action.yml
@@ -1,0 +1,16 @@
+name: "Install TinyGo"
+description: "Installs TinyGo"
+inputs:
+  tinygo-version:
+    description: "The version of TinyGo to install"
+    required: true
+    default: "0.27.0"
+runs:
+  using: "composite"
+  steps:
+    - run: |
+        echo "Install TinyGo ${{ inputs.tinygo-version }}..."
+        wget https://github.com/tinygo-org/tinygo/releases/download/v${{ inputs.tinygo-version }}/tinygo_${{ inputs.tinygo-version }}_amd64.deb
+        sudo dpkg -i tinygo_${{ inputs.tinygo-version }}_amd64.deb
+        echo "/usr/local/tinygo/bin" >> $GITHUB_PATH
+      shell: "bash"

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -6,6 +6,9 @@ jobs:
       matrix:
         go-version: ['1.20', '1.19']
         tinygo-version: ['0.27.0', '0.26.0']
+        exclude:
+          - go-version: '1.20'
+            tinygo-version: '0.26.0'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout fastly/compute-sdk-go

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -2,6 +2,10 @@ name: Build Examples
 on: [push]
 jobs:
   build-examples:
+    strategy:
+      matrix:
+        go-version: ['1.20', '1.19']
+        tinygo-version: ['0.27.0', '0.26.0']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout fastly/compute-sdk-go
@@ -9,16 +13,20 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-         go-version: '1.19'
-      - name: Install Tinygo
-        run: |
-          echo "Install TinyGo 0.26.0..."
-          wget https://github.com/tinygo-org/tinygo/releases/download/v0.26.0/tinygo_0.26.0_amd64.deb
-          echo "dd7d47bc15be3690932394faca93ac6433a309cbe2957fc71e5688e567cd6d1ce0b8bf1e92455058e4547db6a70e176af85fe1b507537966a160bf88a819a101 tinygo_0.26.0_amd64.deb" | sha512sum --check
-          sudo dpkg -i tinygo_0.26.0_amd64.deb
-      - name: build examples
+         go-version: ${{ matrix.go-version }}
+      - name: Install TinyGo
+        uses: ./.github/actions/install-tinygo
+        with:
+          tinygo-version: ${{ matrix.tinygo-version }}
+      - name: Build examples
         run: |
           for i in _examples/*; do
+            echo ${GITHUB_WORKSPACE}/$i
+            cd ${GITHUB_WORKSPACE}/$i && tinygo build -target=wasi
+          done
+      - name: Build integration tests
+        run: |
+          for i in _integration_tests/fixtures/*; do
             echo ${GITHUB_WORKSPACE}/$i
             cd ${GITHUB_WORKSPACE}/$i && tinygo build -target=wasi
           done

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,7 +1,7 @@
 name: Compute TinyGo SDK Test
 on: [push]
 jobs:
-  sdktest-go-latest:
+  sdktest:
     runs-on: ubuntu-latest
     concurrency: 
       group: SdkTestJob
@@ -9,40 +9,21 @@ jobs:
     steps:
       - name: Checkout fastly/compute-sdk-go
         uses: actions/checkout@v2
-      - uses: ./.github/actions/bootstrap-integration-test
-      - name: Check our bootstrap dependencies were installed correctly, and in our $PATH
-        run: |
-          fastly version
-          viceroy --version
-          tinygo version
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-         go-version: '1.19' 
-      - name: compute-sdk-go Integration Tests Job
-        uses: ./.github/actions/compute-sdk-test
-        id: sdktest
+          go-version: '1.20'
+      - name: Install TinyGo
+        uses: ./.github/actions/install-tinygo
         with:
-          config: './_integration_tests/sdk-test-config.json'
-  sdktest-go-previous:
-    runs-on: ubuntu-latest
-    needs: [sdktest-go-latest]
-    concurrency: 
-      group: SdkTestJob
-      cancel-in-progress: true
-    steps:
-      - name: Checkout fastly/compute-sdk-go
-        uses: actions/checkout@v2
+          tinygo-version: '0.27.0'
       - uses: ./.github/actions/bootstrap-integration-test
       - name: Check our bootstrap dependencies were installed correctly, and in our $PATH
         run: |
+          go version
+          tinygo version
           fastly version
           viceroy --version
-          tinygo version
-      - name: Install Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: '1.18' 
       - name: compute-sdk-go Integration Tests Job
         uses: ./.github/actions/compute-sdk-test
         id: sdktest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,9 @@
 name: Validate
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/_app_template/Makefile
+++ b/_app_template/Makefile
@@ -12,7 +12,7 @@ WASM ?= bin/${NAME}.wasm
 PACKAGE ?= pkg/${NAME}.tar.gz
 
 $(WASM): $(SOURCE) Makefile bin
-	env GOROOT=${GOROOT} ${TINYGO} build -target=wasi -wasm-abi=generic -gc=${GC} -scheduler=${SCHEDULER} ${ARGS} -o ${WASM} ./cmd/${NAME}
+	env GOROOT=${GOROOT} ${TINYGO} build -target=wasi -gc=${GC} -scheduler=${SCHEDULER} ${ARGS} -o ${WASM} ./cmd/${NAME}
 
 ${PACKAGE}: pkg ${WASM} fastly.toml
 	${FASTLY} compute pack --wasm-binary=${WASM}

--- a/_integration_tests/fixtures/secret_store/fastly.toml
+++ b/_integration_tests/fixtures/secret_store/fastly.toml
@@ -9,4 +9,4 @@ name = "secret_store"
 service_id = ""
 
 [local_server]
-  secret_store.phrases = [{key = "my_phrase", data = "sssh! don't tell anyone!"}]
+  secret_stores.phrases = [{key = "my_phrase", data = "sssh! don't tell anyone!"}]

--- a/_integration_tests/sdk-test-config.json
+++ b/_integration_tests/sdk-test-config.json
@@ -2,7 +2,7 @@
   "name": "Compute TinyGo SDK",
   "modules": {
     "hello_world" : {
-      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -wasm-abi=generic -o ./_integration_tests/fixtures/hello_world/hello_world.wasm ./_integration_tests/fixtures/hello_world && (cd ./_integration_tests/fixtures/hello_world && fastly compute pack --verbose --wasm-binary ./hello_world.wasm)",
+      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -o ./_integration_tests/fixtures/hello_world/hello_world.wasm ./_integration_tests/fixtures/hello_world && (cd ./_integration_tests/fixtures/hello_world && fastly compute pack --verbose --wasm-binary ./hello_world.wasm)",
       "fastly_toml_path": "./_integration_tests/fixtures/hello_world/fastly.toml",
       "wasm_path": "./_integration_tests/fixtures/hello_world/hello_world.wasm",
       "pkg_path": "./_integration_tests/fixtures/hello_world/pkg/hello-world.tar.gz",
@@ -22,7 +22,7 @@
     },
 
     "request_downstream" : {
-      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -wasm-abi=generic -o ./_integration_tests/fixtures/request_downstream/request_downstream.wasm ./_integration_tests/fixtures/request_downstream && (cd ./_integration_tests/fixtures/request_downstream && fastly compute pack --verbose --wasm-binary ./request_downstream.wasm)",
+      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -o ./_integration_tests/fixtures/request_downstream/request_downstream.wasm ./_integration_tests/fixtures/request_downstream && (cd ./_integration_tests/fixtures/request_downstream && fastly compute pack --verbose --wasm-binary ./request_downstream.wasm)",
       "fastly_toml_path": "./_integration_tests/fixtures/request_downstream/fastly.toml",
       "wasm_path": "./_integration_tests/fixtures/request_downstream/request_downstream.wasm",
       "pkg_path": "./_integration_tests/fixtures/request_downstream/pkg/request-downstream.tar.gz",
@@ -51,7 +51,7 @@
     },
 
     "async_select" : {
-      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -wasm-abi=generic -o ./_integration_tests/fixtures/async_select/async_select.wasm ./_integration_tests/fixtures/async_select && (cd ./_integration_tests/fixtures/async_select && fastly compute pack --verbose --wasm-binary ./async_select.wasm)",
+      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -o ./_integration_tests/fixtures/async_select/async_select.wasm ./_integration_tests/fixtures/async_select && (cd ./_integration_tests/fixtures/async_select && fastly compute pack --verbose --wasm-binary ./async_select.wasm)",
       "fastly_toml_path": "./_integration_tests/fixtures/async_select/fastly.toml",
       "wasm_path": "./_integration_tests/fixtures/async_select/async_select.wasm",
       "pkg_path": "./_integration_tests/fixtures/async_select/pkg/async-select.tar.gz",
@@ -75,7 +75,7 @@
     },
 
     "byte_repeater" : {
-      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -wasm-abi=generic -o ./_integration_tests/fixtures/byte_repeater/byte_repeater.wasm ./_integration_tests/fixtures/byte_repeater && (cd ./_integration_tests/fixtures/byte_repeater && fastly compute pack --verbose --wasm-binary ./byte_repeater.wasm)",
+      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -o ./_integration_tests/fixtures/byte_repeater/byte_repeater.wasm ./_integration_tests/fixtures/byte_repeater && (cd ./_integration_tests/fixtures/byte_repeater && fastly compute pack --verbose --wasm-binary ./byte_repeater.wasm)",
       "fastly_toml_path": "./_integration_tests/fixtures/byte_repeater/fastly.toml",
       "wasm_path": "./_integration_tests/fixtures/byte_repeater/byte_repeater.wasm",
       "pkg_path": "./_integration_tests/fixtures/byte_repeater/pkg/byte-repeater.tar.gz",
@@ -99,7 +99,7 @@
 
 
     "configstore" : {
-      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -wasm-abi=generic -o ./_integration_tests/fixtures/configstore/configstore.wasm ./_integration_tests/fixtures/configstore && (cd ./_integration_tests/fixtures/configstore && fastly compute pack --verbose --wasm-binary ./configstore.wasm)",
+      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -o ./_integration_tests/fixtures/configstore/configstore.wasm ./_integration_tests/fixtures/configstore && (cd ./_integration_tests/fixtures/configstore && fastly compute pack --verbose --wasm-binary ./configstore.wasm)",
       "fastly_toml_path": "./_integration_tests/fixtures/configstore/fastly.toml",
       "wasm_path": "./_integration_tests/fixtures/configstore/configstore.wasm",
       "pkg_path": "./_integration_tests/fixtures/configstore/pkg/configstore.tar.gz",
@@ -120,7 +120,7 @@
     },
 
     "request_upstream" : {
-      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -wasm-abi=generic -o ./_integration_tests/fixtures/request_upstream/request_upstream.wasm ./_integration_tests/fixtures/request_upstream && (cd ./_integration_tests/fixtures/request_upstream && fastly compute pack --verbose --wasm-binary ./request_upstream.wasm)",
+      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -o ./_integration_tests/fixtures/request_upstream/request_upstream.wasm ./_integration_tests/fixtures/request_upstream && (cd ./_integration_tests/fixtures/request_upstream && fastly compute pack --verbose --wasm-binary ./request_upstream.wasm)",
       "fastly_toml_path": "./_integration_tests/fixtures/request_upstream/fastly.toml",
       "wasm_path": "./_integration_tests/fixtures/request_upstream/request_upstream.wasm",
       "pkg_path": "./_integration_tests/fixtures/request_upstream/pkg/request-upstream.tar.gz",
@@ -144,7 +144,7 @@
     },
 
     "rtlog" : {
-      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -wasm-abi=generic -o ./_integration_tests/fixtures/rtlog/rtlog.wasm ./_integration_tests/fixtures/rtlog && (cd ./_integration_tests/fixtures/rtlog && fastly compute pack --verbose --wasm-binary ./rtlog.wasm)",
+      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -o ./_integration_tests/fixtures/rtlog/rtlog.wasm ./_integration_tests/fixtures/rtlog && (cd ./_integration_tests/fixtures/rtlog && fastly compute pack --verbose --wasm-binary ./rtlog.wasm)",
       "fastly_toml_path": "./_integration_tests/fixtures/rtlog/fastly.toml",
       "wasm_path": "./_integration_tests/fixtures/rtlog/rtlog.wasm",
       "pkg_path": "./_integration_tests/fixtures/rtlog/pkg/rtlog.tar.gz",
@@ -168,7 +168,7 @@
     },
 
     "status" : {
-      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -wasm-abi=generic -o ./_integration_tests/fixtures/status/status.wasm ./_integration_tests/fixtures/status && (cd ./_integration_tests/fixtures/status && fastly compute pack --verbose --wasm-binary ./status.wasm)",
+      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -o ./_integration_tests/fixtures/status/status.wasm ./_integration_tests/fixtures/status && (cd ./_integration_tests/fixtures/status && fastly compute pack --verbose --wasm-binary ./status.wasm)",
       "fastly_toml_path": "./_integration_tests/fixtures/status/fastly.toml",
       "wasm_path": "./_integration_tests/fixtures/status/status.wasm",
       "pkg_path": "./_integration_tests/fixtures/status/pkg/status.tar.gz",
@@ -188,7 +188,7 @@
     },
 
     "streaming_close" : {
-      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -wasm-abi=generic -o ./_integration_tests/fixtures/streaming_close/streaming_close.wasm ./_integration_tests/fixtures/streaming_close && (cd ./_integration_tests/fixtures/streaming_close && fastly compute pack --verbose --wasm-binary ./streaming_close.wasm)",
+      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -o ./_integration_tests/fixtures/streaming_close/streaming_close.wasm ./_integration_tests/fixtures/streaming_close && (cd ./_integration_tests/fixtures/streaming_close && fastly compute pack --verbose --wasm-binary ./streaming_close.wasm)",
       "fastly_toml_path": "./_integration_tests/fixtures/streaming_close/fastly.toml",
       "wasm_path": "./_integration_tests/fixtures/streaming_close/streaming_close.wasm",
       "pkg_path": "./_integration_tests/fixtures/streaming_close/pkg/streaming-close.tar.gz",
@@ -221,7 +221,7 @@
     },
 
     "secret_store" : {
-      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -wasm-abi=generic -o ./_integration_tests/fixtures/secret_store/secret_store.wasm ./_integration_tests/fixtures/secret_store && (cd ./_integration_tests/fixtures/secret_store && fastly compute pack --verbose --wasm-binary ./secret_store.wasm)",
+      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -o ./_integration_tests/fixtures/secret_store/secret_store.wasm ./_integration_tests/fixtures/secret_store && (cd ./_integration_tests/fixtures/secret_store && fastly compute pack --verbose --wasm-binary ./secret_store.wasm)",
       "fastly_toml_path": "./_integration_tests/fixtures/secret_store/fastly.toml",
       "wasm_path": "./_integration_tests/fixtures/secret_store/secret_store.wasm",
       "pkg_path": "./_integration_tests/fixtures/secret_store/pkg/secret-store.tar.gz",


### PR DESCRIPTION
Drop obsolete `-wasm-abi=generic` flag from TinyGo builds.

Update tooling: 
* Fastly CLI to v8.1.2
* Viceroy to v0.4.0
* TinyGo to v0.27.0.

This also reworks some of the details of CI runs:
* Create an "Install TinyGo" action and use it in workflows to eliminate duplicate manual installation work
* Build integration tests as part of the "Build examples" workflow
* Use a matrix strategy with "Build examples" so it builds with combinations of Go 1.20 and Go 1.19, and TinyGo 0.27.0 and TinyGo 0.26.0, which should help us find build errors due to version incompatibilities.
* Run the integration tests only once, against the latest Go and TinyGo releases.
* Make the "Validate" action run only once in a PR, by setting it to run on all `pull_request` actions and only on `push` to `main`.
