### PR TITLE
don't stream certain in-memory io.Readers

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           for i in _examples/*/; do
             echo ${GITHUB_WORKSPACE}/$i
-            cd ${GITHUB_WORKSPACE}/$i && tinygo build -target=wasi
+            cd ${GITHUB_WORKSPACE}/$i && tinygo build -target=wasi -tags fastlyinternaldebug
           done
   build-examples-go:
     strategy:
@@ -45,5 +45,5 @@ jobs:
         run: |
           for i in _examples/*/; do
             echo ${GITHUB_WORKSPACE}/$i
-            cd ${GITHUB_WORKSPACE}/$i && env GOARCH=wasm GOOS=wasip1 go build
+            cd ${GITHUB_WORKSPACE}/$i && env GOARCH=wasm GOOS=wasip1 go build -tags fastlyinternaldebug
           done

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,7 +42,7 @@ jobs:
           fastly version
           viceroy --version
       - name: Run Integration Tests
-        run: RUST_LOG="viceroy=info,viceroy-lib=info" tinygo test -v -target=fastly-compute.json ./integration_tests/...
+        run: RUST_LOG="viceroy=info,viceroy-lib=info" tinygo test -v -target=fastly-compute.json -tags fastlyinternaldebug ./integration_tests/...
   integration-tests-go:
     runs-on: ubuntu-latest
     steps:
@@ -68,4 +68,4 @@ jobs:
           fastly version
           viceroy --version
       - name: Run Integration Tests
-        run: RUST_LOG="viceroy=info,viceroy-lib=info" GOARCH=wasm GOOS=wasip1 go test -exec "viceroy run -C fastly.toml" -v ./integration_tests/...
+        run: RUST_LOG="viceroy=info,viceroy-lib=info" GOARCH=wasm GOOS=wasip1 go test -tags fastlyinternaldebug -exec "viceroy run -C fastly.toml" -v ./integration_tests/...

--- a/integration_tests/request_upstream/fastly.toml
+++ b/integration_tests/request_upstream/fastly.toml
@@ -20,3 +20,6 @@ service_id = ""
 
     [local_server.backends.example_backend]
       url = "https://example.org/"
+
+    [local_server.backends.httpme]
+      url = "https://http-me.glitch.me"


### PR DESCRIPTION
`bytes.Buffer`, `bytes.Reader`, and `strings.Reader` are all `io.Reader`
implementations on an in-memory buffer.  Their sizes are known ahead of
time, and these types tend to be used for small payloads.  We can send
these payloads with a `Content-Length` rather than using chunked
encoding by sending them with `SendAsync` rather than
`SendAsyncStreaming`.
