### PR TITLE
add LimitExceeded FastlyStatus code; print unknown codes

### DIFF
--- a/internal/abi/fastly/types.go
+++ b/internal/abi/fastly/types.go
@@ -113,7 +113,7 @@ func (s FastlyStatus) String() string {
 	case FastlyStatusLimitExceeded:
 		return "LimitExceeded"
 	default:
-		return fmt.Printf("unknown error code: %d", s)
+		return fmt.Sprintf("unknown error code: %d", s)
 	}
 }
 

--- a/internal/abi/fastly/types.go
+++ b/internal/abi/fastly/types.go
@@ -33,7 +33,8 @@ type FastlyStatus uint32
 //          $httpincomplete
 //          $none
 //          $httpheadtoolarge
-//          $httpinvalidstatus))
+//          $httpinvalidstatus
+//          $limitexceeded))
 
 const (
 	// FastlyStatusOK maps to $fastly_status $ok.
@@ -75,6 +76,9 @@ const (
 
 	// FastlyStatusHTTPInvalidStatus maps to $fastly_status $httpinvalidstatus.
 	FastlyStatusHTTPInvalidStatus FastlyStatus = 12
+
+	// FastlyStatusLimitExceeded maps to $fastly_status $limitexceeded.
+	FastlyStatusLimitExceeded FastlyStatus = 13
 )
 
 // String implements fmt.Stringer.
@@ -106,8 +110,10 @@ func (s FastlyStatus) String() string {
 		return "HTTPHeadTooLarge"
 	case FastlyStatusHTTPInvalidStatus:
 		return "HTTPInvalidStatus"
+	case FastlyStatusLimitExceeded:
+		return "LimitExceeded"
 	default:
-		return "unknown"
+		return fmt.Printf("unknown error code: %d", s)
 	}
 }
 


### PR DESCRIPTION
LimitExceeded was added last year, and printing unknown codes will help when debugging situations when the definitions get out of sync.

I do not have a Go dev environment set up, so I have not compiled or tested this 😬 but hopefully it's a small enough addition that CI will be happy.