### PR TITLE
Implement Core Cache and Purge APIs

### DIFF
--- a/_examples/corecache/main.go
+++ b/_examples/corecache/main.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/fastly/compute-sdk-go/cache/core"
+	"github.com/fastly/compute-sdk-go/fsthttp"
+)
+
+func main() {
+	fsthttp.ServeFunc(func(ctx context.Context, w fsthttp.ResponseWriter, r *fsthttp.Request) {
+		key := keyForRequest(r)
+		switch r.Method {
+
+		// Fetch content from the cache.
+		case "GET":
+			tx, err := core.NewTransaction(key, core.LookupOptions{})
+			if err != nil {
+				fsthttp.Error(w, err.Error(), fsthttp.StatusInternalServerError)
+				return
+			}
+			defer tx.Close()
+
+			f, err := tx.Found()
+			if errors.Is(err, core.ErrNotFound) {
+				fsthttp.Error(w, err.Error(), fsthttp.StatusNotFound)
+				return
+			}
+			if err != nil {
+				fsthttp.Error(w, err.Error(), fsthttp.StatusInternalServerError)
+				return
+			}
+			defer f.Body.Close()
+
+			msg, err := io.ReadAll(f.Body)
+			if err != nil {
+				fsthttp.Error(w, err.Error(), fsthttp.StatusInternalServerError)
+				return
+			}
+
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprintf(w, "%s's message for %s is: %s\n", getPOP(), r.URL.Path, msg)
+
+		// Write data to the cache and stream it back to the client.
+		case "POST":
+			if r.Header.Get("Content-Type") != "text/plain" && r.Header.Get("Content-Type") != "text/plain; charset=utf-8" {
+				w.WriteHeader(fsthttp.StatusUnsupportedMediaType)
+				return
+			}
+
+			msg, err := io.ReadAll(r.Body)
+			if err != nil {
+				fsthttp.Error(w, err.Error(), fsthttp.StatusInternalServerError)
+				return
+			}
+
+			tx, err := core.NewTransaction(key, core.LookupOptions{})
+			if err != nil {
+				fsthttp.Error(w, err.Error(), fsthttp.StatusInternalServerError)
+				return
+			}
+			defer tx.Close()
+
+			if !tx.MustInsert() {
+				w.WriteHeader(fsthttp.StatusConflict)
+				return
+			}
+
+			// We call InsertAndStreamBack to create both a handle to
+			// write the content into the cache and a Found object to
+			// stream the contents back out to the client.  As soon as
+			// data is written to the insert body, it is immediately
+			// streamed to all clients waiting on this transaction,
+			// including this one.
+			//
+			// This is preferable to using an io.MultiWriter because a
+			// MultiWriter is constrained by the slowest writer.  If
+			// other transactions are waiting on the content to be
+			// written to the cache and streamed, we don't want that
+			// process to be delayed by a slow client for this request.
+			insertBody, found, err := tx.InsertAndStreamBack(core.WriteOptions{
+				TTL:           600 * time.Second,
+				Length:        uint64(len(msg)),
+				SurrogateKeys: []string{hex.EncodeToString(key)},
+			})
+			if err != nil {
+				fsthttp.Error(w, err.Error(), fsthttp.StatusInternalServerError)
+				return
+			}
+			defer found.Body.Close()
+
+			insertBody.Write(msg)
+
+			if err := insertBody.Close(); err != nil {
+				fsthttp.Error(w, err.Error(), fsthttp.StatusInternalServerError)
+				return
+			}
+
+			msg, err = io.ReadAll(found.Body)
+			if err != nil {
+				fsthttp.Error(w, err.Error(), fsthttp.StatusInternalServerError)
+				return
+			}
+
+			w.Header().Set("Content-Type", "text/plain")
+			w.WriteHeader(fsthttp.StatusCreated)
+			fmt.Fprintf(w, "%s's message for %s is: %s\n", getPOP(), r.URL.Path, msg)
+
+		// Purge the key from the cache.
+		case "DELETE":
+			// TODO: purge the surrogate key.
+			w.WriteHeader(fsthttp.StatusNotImplemented)
+
+		default:
+			w.WriteHeader(fsthttp.StatusMethodNotAllowed)
+		}
+	})
+}
+
+func keyForRequest(r *fsthttp.Request) []byte {
+	h := sha256.New()
+	h.Write([]byte(r.URL.Path))
+	h.Write([]byte(getPOP()))
+	return h.Sum(nil)
+}
+
+func getPOP() string {
+	return os.Getenv("FASTLY_POP")
+}

--- a/_examples/corecache/main.go
+++ b/_examples/corecache/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/fastly/compute-sdk-go/cache/core"
 	"github.com/fastly/compute-sdk-go/fsthttp"
+	"github.com/fastly/compute-sdk-go/purge"
 )
 
 func main() {
@@ -115,8 +116,11 @@ func main() {
 
 		// Purge the key from the cache.
 		case "DELETE":
-			// TODO: purge the surrogate key.
-			w.WriteHeader(fsthttp.StatusNotImplemented)
+			if err := purge.PurgeSurrogateKey(hex.EncodeToString(key), purge.PurgeOptions{}); err != nil {
+				fsthttp.Error(w, err.Error(), fsthttp.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(fsthttp.StatusAccepted)
 
 		default:
 			w.WriteHeader(fsthttp.StatusMethodNotAllowed)

--- a/cache/core/core.go
+++ b/cache/core/core.go
@@ -1,0 +1,757 @@
+// Package core provides the Fastly Core Cache API.
+//
+// This package exposes the primitive operations required to implement
+// high-performance cache applications with advanced features such as
+// [request collapsing], [streaming miss], [revalidation], and
+// [surrogate key purging].
+//
+// While this API contains affordances for some HTTP caching concepts
+// such as Vary headers and stale-while-revalidate, this API is not
+// suitable for HTTP caching out-of-the-box.  Future SDK releases will
+// add a more customizable HTTP Cache API with support for customizable
+// read-through caching, freshness lifetime inference, conditional
+// request evaluation, automatic revalidation, and more.
+//
+// Cached items in this API consist of:
+//
+//   - A cache key: up to 4096 bytes of arbtirary data that identify a
+//     cached object.  The cache key may not uniquely identify an item;
+//     headers can be used to augment the key when multiple items are
+//     associated with the same key.
+//
+//   - General metadata, such as expiry data (item age, when to expire,
+//     and surrogate keys for purging).
+//
+//   - User-controlled metadata: arbitrary bytes stored alongside the
+//     cached object that can be updated when revalidating the cached
+//     object.
+//
+//   - The object itself: arbitrary bytes read via an [io.ReadCloser] and
+//     written via a [WriteCloseAbandoner].
+//
+// In the simplest cases, the top-level [Insert] and [Lookup] functions
+// are used for one-off operations on a cached object, and are
+// appropriate when request collapsing and revalidation capabilities are
+// not required.
+//
+// The API also supports more complex uses via [Transaction], which can
+// collapse concurrent lookups to the same item, including coordinating
+// revalidation.
+//
+// [request collapsing]: https://developer.fastly.com/learning/concepts/request-collapsing/
+// [streaming miss]: https://docs.fastly.com/en/guides/streaming-miss
+// [revalidation]: https://developer.fastly.com/learning/concepts/stale/
+// [surrogate key purging]: https://docs.fastly.com/en/guides/purging-api-cache-with-surrogate-keys
+package core
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/fastly/compute-sdk-go/fsthttp"
+	"github.com/fastly/compute-sdk-go/internal/abi/fastly"
+)
+
+var (
+	// ErrNotFound is returned when a cache lookup fails to find a
+	// cached object with the provided key.
+	ErrNotFound = errors.New("cache: object not found")
+
+	// ErrInvalidArgument is returned when an argument passed to a
+	// function is invalid.
+	ErrInvalidArgument = errors.New("cache: invalid argument")
+
+	// ErrInvalidOperation is returned when an operation to be performed
+	// is not valid given the state of the cached object.
+	ErrInvalidOperation = errors.New("cache: invalid operation")
+
+	// ErrLimitExceeded is returned when a cache operation exceeds the
+	// limits allowed for this service.
+	ErrLimitExceeded = errors.New("cache: operation limit exceeded")
+
+	// ErrUnsupported is returned when a cache operation is not
+	// supported.
+	ErrUnsupported = errors.New("cache: operation not supported")
+)
+
+// Found represents a cached object found by a cache lookup.
+type Found struct {
+	abiEntry     *fastly.CacheEntry
+	state        fastly.CacheLookupState
+	userMetadata []byte
+
+	// Key is the cache key used to find this object.
+	Key []byte
+
+	// TTL is the time for which the cached object is considered fresh.
+	TTL time.Duration
+
+	// Length is the length of the cached object in bytes, if known.
+	// The length of the cached item may be unknown if the item is
+	// currently being streamed into the cache without a fixed length.
+	Length uint64
+
+	// Age is the age of the cached object at lookup time.
+	Age time.Duration
+
+	// StaleWhileRevalidate is the period of time that the cached object
+	// can be served stale while revalidation takes place.
+	//
+	// This provides a signal that the cache should be updated (or its
+	// contents otherwise revalidated for freshness) asynchronously,
+	// while the stale cached object continues to be used, rather than
+	// blocking on updating the cached object.  The default
+	// stale-while-revalidate period is zero.
+	StaleWhileRevalidate time.Duration
+
+	// Hits is the number of times the cached object has been served.
+	// This count only reflects the view of the server that supplied the
+	// cached object.  Due to clustering, this count may vary between
+	// potentially many servers within the data center where the item is
+	// cached.  See the clustering documentation for details:
+	// https://developer.fastly.com/learning/vcl/clustering/
+	Hits uint64
+
+	// Body is an io.ReadCloser for the cached object.  It must be
+	// closed when finished.
+	Body io.ReadCloser
+}
+
+func newFound(key []byte, e *fastly.CacheEntry, state fastly.CacheLookupState, opts LookupOptions) (*Found, error) {
+	ttl, err := e.MaxAge()
+	if err := ignoreNoneError(err); err != nil {
+		return nil, mapFastlyError(err)
+	}
+
+	length, err := e.Length()
+	if err := ignoreNoneError(err); err != nil {
+		return nil, mapFastlyError(err)
+	}
+
+	age, err := e.Age()
+	if err := ignoreNoneError(err); err != nil {
+		return nil, mapFastlyError(err)
+	}
+
+	staleWhileRevalidate, err := e.StaleWhileRevalidate()
+	if err := ignoreNoneError(err); err != nil {
+		return nil, mapFastlyError(err)
+	}
+
+	hits, err := e.Hits()
+	if err := ignoreNoneError(err); err != nil {
+		return nil, mapFastlyError(err)
+	}
+
+	var bopts fastly.CacheGetBodyOptions
+	if opts.From > 0 {
+		bopts.From(opts.From)
+	}
+	if opts.To > 0 {
+		bopts.To(opts.To)
+	}
+	body, err := e.Body(bopts)
+	if err := ignoreNoneError(err); err != nil {
+		return nil, mapFastlyError(err)
+	}
+
+	return &Found{
+		abiEntry:             e,
+		state:                state,
+		Key:                  key,
+		TTL:                  ttl,
+		Length:               length,
+		Age:                  age,
+		StaleWhileRevalidate: staleWhileRevalidate,
+		Hits:                 hits,
+		Body:                 &bodyWrapper{body},
+	}, nil
+}
+
+// Stale returns true if the cached object is stale.
+func (f *Found) Stale() bool {
+	return f.state&fastly.CacheLookupStateStale != 0
+}
+
+// Usable returns true if the cached object is usable.
+func (f *Found) Usable() bool {
+	return f.state&fastly.CacheLookupStateUsable != 0
+}
+
+// UserMetadata returns user-provided metadata associated with the
+// cached object.  It will return an empty slice if no metadata was
+// provided when the object was inserted.
+func (f *Found) UserMetadata() ([]byte, error) {
+	if f.userMetadata != nil {
+		return f.userMetadata, nil
+	}
+
+	userMetadata, err := f.abiEntry.UserMetadata()
+	if err := ignoreNoneError(err); err != nil {
+		return nil, mapFastlyError(err)
+	}
+
+	f.userMetadata = userMetadata
+	return userMetadata, nil
+}
+
+// GetRange returns an [io.ReadCloser] for the provided range of bytes.
+// The Found's Body must be closed before calling this function, or it
+// will return [ErrInvalidOperation].
+func (f *Found) GetRange(from, to uint64) (io.ReadCloser, error) {
+	var bopts fastly.CacheGetBodyOptions
+	if from > 0 {
+		bopts.From(from)
+	}
+	if to > 0 {
+		bopts.To(to)
+	}
+
+	body, err := f.abiEntry.Body(bopts)
+	if err := ignoreNoneError(err); err != nil {
+		return nil, mapFastlyError(err)
+	}
+
+	return &bodyWrapper{body}, nil
+}
+
+func requestHeadersBody(h fsthttp.Header) (*fastly.HTTPRequest, error) {
+	req, err := fastly.NewHTTPRequest()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, key := range h.Keys() {
+		vals := h.Values(key)
+		if err := req.SetHeaderValues(key, vals); err != nil {
+			return nil, fmt.Errorf("set headers: %w", err)
+		}
+	}
+
+	return req, nil
+}
+
+// LookupOptions control the behavior of cache lookups and the objects
+// returned.
+type LookupOptions struct {
+	// RequestHeaders are a set of HTTP headers that influence cache
+	// lookups when Vary rules are set.
+	//
+	// A lookup will succeed when there is at least one cached object
+	// that matches the lookup's cache key, and all of the headers
+	// included in the cached object's Vary list match the corresponding
+	// headers in that cached object.
+	RequestHeaders fsthttp.Header
+
+	// From indicates the starting offset to read from the cached
+	// object.
+	From uint64
+
+	// To indicates the ending offset to read from the cached object.  A
+	// value of 0 means to read to the end of the object.
+	To uint64
+}
+
+func abiLookupOptions(opts LookupOptions) (fastly.CacheLookupOptions, error) {
+	var abiOpts fastly.CacheLookupOptions
+
+	if opts.RequestHeaders != nil {
+		req, err := requestHeadersBody(opts.RequestHeaders)
+		if err != nil {
+			return abiOpts, err
+		}
+
+		abiOpts.SetRequest(req)
+	}
+
+	return abiOpts, nil
+}
+
+// Lookup performs a simple, non-transactional lookup for the given key.
+// If the key is not cached, [ErrNotFound] is returned.  Keys can be up
+// to 4096 bytes in length.
+//
+// In contrast to lookups using [NewTransaction], this will not
+// coordinate with any concurrent cache lookups.  No request collapsing
+// is done.
+func Lookup(key []byte, opts LookupOptions) (*Found, error) {
+	abiOpts, err := abiLookupOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	e, err := fastly.CacheLookup(key, abiOpts)
+	if err != nil {
+		return nil, mapFastlyError(err)
+	}
+
+	state, err := e.State()
+	if err != nil {
+		e.Close()
+		return nil, mapFastlyError(err)
+	}
+
+	if state&fastly.CacheLookupStateFound == 0 {
+		e.Close()
+		return nil, ErrNotFound
+	}
+
+	f, err := newFound(key, e, state, opts)
+	if err != nil {
+		e.Close()
+		return nil, err
+	}
+
+	// Note that for Found objects created by this Lookup function, we
+	// never close the underlying abiEntry.  This isn't ideal but it
+	// makes for a nicer API.  Otherwise we would need to add a Close
+	// method for Founds created from this function, whereas Found
+	// objects from a transaction wouldn't need to be closed.
+
+	return f, nil
+}
+
+// WriteOptions control the behavior of cache inserts and updates.  TTL
+// is required, but all other fields are optional.
+type WriteOptions struct {
+	// TTL is the maximum time the cached object will be considered
+	// fresh.  Required.
+	TTL time.Duration
+
+	// RequestHeaders are a set of HTTP headers that influence cache
+	// lookups when Vary rules are set.
+	//
+	// This field is only valid for Insert.  If provided for Update,
+	// ErrInvalidArgument will be returned.
+	RequestHeaders fsthttp.Header
+
+	// Vary is a list of HTTP header names (provided in RequestHeaders)
+	// that must match when looking up this key.
+	Vary []string
+
+	// InitialAge is the initial age of the cached object.
+	InitialAge time.Duration
+
+	// StaleWhileRevalidate is the period of time in which the cached
+	// object can be served stale while revalidation is taking place.
+	//
+	// This provides a signal that the cache should be updated (or its
+	// contents otherwise revalidated for freshness) asynchronously,
+	// while the stale cached object continues to be used, rather than
+	// blocking on updating the cached object.  The methods Usable and
+	// Stale can be used to determine the current state of a found item.
+	StaleWhileRevalidate time.Duration
+
+	// SurrogateKeys is a list of surrogate keys which can be used to
+	// purge this object.
+	//
+	// Surrogate key purges are the only means to purge specific items
+	// from the cache.  At least one surrogate key must be set in order
+	// to remove an item without performaing a purge-all, waiting for
+	// the item's TTL to elapse, or overwriting the item with Insert.
+	//
+	// Surrogate keys must contain only printable ASCII characters
+	// (those between 0x21 and 0x7E, inclusive).  Any invalid keys will
+	// be ignored.
+	//
+	// See the Fastly surrogate keys guide for details:
+	// https://docs.fastly.com/en/guides/purging-api-cache-with-surrogate-keys
+	SurrogateKeys []string
+
+	// Length sets the size of the cached object, in bytes, when known
+	// prior to actually providing the bytes.
+	//
+	// It is preferable to provide a length, if possible.  Clients that
+	// begin streaming the object's contents before it is completely
+	// provided will see the promised length which allows them to, for
+	// example, use Content-Length instead of chunked Transfer-Encoding
+	// if the item is used as the body of an HTTP request or response.
+	Length uint64
+
+	// UserMetadata is abitrary user-provided metadata that will be
+	// associated with the cached object.
+	UserMetadata []byte
+
+	// SensitiveData indiciates whether to enable PCI/HIPAA-compliant
+	// non-volatile caching.
+	//
+	// See the Fastly PCI-Compliant Caching and Delivery documentation
+	// for details:
+	// https://docs.fastly.com/products/pci-compliant-caching-and-delivery
+	SensitiveData bool
+}
+
+func abiWriteOptions(opts WriteOptions) (fastly.CacheWriteOptions, error) {
+	var wopts fastly.CacheWriteOptions
+	wopts.MaxAge(opts.TTL)
+
+	if len(opts.RequestHeaders) > 0 {
+		req, err := requestHeadersBody(opts.RequestHeaders)
+		if err != nil {
+			return wopts, err
+		}
+
+		wopts.SetRequest(req)
+	}
+
+	if len(opts.Vary) > 0 {
+		wopts.Vary(opts.Vary)
+	}
+
+	if opts.InitialAge > 0 {
+		wopts.InitialAge(opts.InitialAge)
+	}
+
+	if opts.StaleWhileRevalidate > 0 {
+		wopts.StaleWhileRevalidate(opts.StaleWhileRevalidate)
+	}
+
+	if len(opts.SurrogateKeys) > 0 {
+		wopts.SurrogateKeys(opts.SurrogateKeys)
+	}
+
+	if opts.Length > 0 {
+		wopts.ContentLength(opts.Length)
+	}
+
+	if len(opts.UserMetadata) > 0 {
+		wopts.UserMetadata(opts.UserMetadata)
+	}
+
+	wopts.SensitiveData(opts.SensitiveData)
+
+	return wopts, nil
+}
+
+// WriteCloseAbandoner is an interface returned by cache insert
+// operations.  It is an [io.WriteCloser] that also supports abandoning
+// the stream.  When Abandon is called, the insert operation is canceled
+// and content written is not saved into the cache.
+type WriteCloseAbandoner interface {
+	io.WriteCloser
+	Abandon() error
+}
+
+// Insert creates a [WriteCloseAbandoner] used for inserting an object
+// into the cache for the given key.  For the insertion to complete
+// successfully, the object must be fully written to the writer and its
+// Close method called.
+//
+// If Close is not called, or the writer's Abandon method is called, the
+// insertion is incomplete and any concurrent lookups that may be
+// reading from the object as it is streamed into the cache may
+// encounter an error while reading.
+//
+// Unlike [Transaction.Insert], this does not coordinate with any other
+// lookups or inserts for this key.  Concurrent inserts may race with
+// concurrent lookups or insertions, and will unconditionally overwrite
+// existing cached items rather than allowing for revalidation of an
+// existing object.
+func Insert(key []byte, opts WriteOptions) (WriteCloseAbandoner, error) {
+	wopts, err := abiWriteOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	wca, err := fastly.CacheInsert(key, wopts)
+	if err != nil {
+		return nil, mapFastlyError(err)
+	}
+
+	return wca, nil
+}
+
+// Transaction represents a construct to coordinate concurrent actions
+// for the same cache key.
+//
+// Transactions incorporate concepts of [request collapsing] and
+// [revalidation], though at a lower level that does not automatically
+// interpret HTTP semantics.
+//
+// # Request collapsing
+//
+// If there are multiple concurrent calls to [NewTransaction] for
+// the same object and that object is not present, only one of the
+// callers will be instructed to insert the item into the cache as part
+// of the transaction.  The other callers will block until the metadata
+// for the object has been inserted, and can then begin streaming its
+// contents out of the cache at the same time that the inserting caller
+// streams them into the cache.
+//
+// # Revalidation
+//
+// Similarly, if an item is usable but stale, and multiple callers
+// attempt a lookup concurrently, they will all be given access to the
+// stale item, but only one will be designated to perform an update (or
+// insertion) to freshen the item in the cache.
+//
+// [request collapsing]: https://developer.fastly.com/learning/concepts/request-collapsing/
+// [revalidation]: https://developer.fastly.com/learning/concepts/stale/
+type Transaction struct {
+	abiEntry *fastly.CacheEntry
+	key      []byte
+	state    fastly.CacheLookupState
+	opts     LookupOptions
+	found    *Found
+	ended    bool
+}
+
+// NewTransaction creates a new cache transaction for the given key.
+//
+// Transactions must be closed by calling the [Transaction.Close] method
+// when finished.
+//
+// Keys can be up to 4096 bytes in length.
+func NewTransaction(key []byte, opts LookupOptions) (*Transaction, error) {
+	abiOpts, err := abiLookupOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	e, err := fastly.CacheTransactionLookup(key, abiOpts)
+	if err != nil {
+		return nil, mapFastlyError(err)
+	}
+
+	// Concurrent lookups for the same key will block on this call.
+	state, err := e.State()
+	if err != nil {
+		e.Close()
+		return nil, mapFastlyError(err)
+	}
+
+	return &Transaction{
+		abiEntry: e,
+		key:      key,
+		state:    state,
+		opts:     opts,
+	}, nil
+}
+
+// Found returns information about the found cached object, if one is
+// available.  If there is no cached object, [ErrNotFound] is returned.
+//
+// Even if an object is found, the cache item might be stale and require
+// updating.  Use [Transaction.MustInsertOrUpdate] to determine whether
+// this transaction client is expected to update the cached object.
+func (t *Transaction) Found() (*Found, error) {
+	if t.state&fastly.CacheLookupStateFound == 0 {
+		return nil, ErrNotFound
+	}
+
+	if t.found == nil {
+		f, err := newFound(t.key, t.abiEntry, t.state, t.opts)
+		if err != nil {
+			return nil, mapFastlyError(err)
+		}
+		t.found = f
+	}
+
+	return t.found, nil
+}
+
+// MustInsert returns true if a usable cached item was not found, and
+// this transaction client is expected to insert one.
+//
+// Use [Transaction.Insert] to insert the object, or
+// [Transaction.Cancel] to exit the transaction without providing an
+// object.
+func (t *Transaction) MustInsert() bool {
+	return t.state&fastly.CacheLookupStateFound == 0 && t.state&fastly.CacheLookupStateMustInsertOrUpdate != 0
+}
+
+// MustInsertOrUpdate returns true if this transaction client is
+// expected to insert a new item or update a stale item.
+//
+// Use:
+//   - [Transaction.Update] to freshen a found item by updating its metadata,
+//   - [Transaction.Insert] to insert a new item including object data,
+//   - [Transaction.Cancel] to exit the transaction without providing an object.
+func (t *Transaction) MustInsertOrUpdate() bool {
+	return t.state&fastly.CacheLookupStateMustInsertOrUpdate != 0
+}
+
+// Insert creates a [WriteCloseAbandoner] used for inserting an object
+// into the cache for this transaction's key.  For the insertion to
+// complete successfully, the object must be fully written to the writer
+// and its Close method called.
+//
+// If Close is not called, or the writer's Abandon method is called,
+// the insertion is incomplete and any concurrent lookups that may be
+// reading from the object as it is streamed into the cache may
+// encounter an error while reading.
+//
+// Inserting an object into the cache will unblock other transactions
+// waiting on this object, streaming the contents to clients as the data
+// is written.
+func (t *Transaction) Insert(opts WriteOptions) (WriteCloseAbandoner, error) {
+	wopts, err := abiWriteOptions(opts)
+	if err != nil {
+		return nil, err
+	}
+
+	wca, err := t.abiEntry.Insert(wopts)
+	if err != nil {
+		return nil, mapFastlyError(err)
+	}
+
+	return wca, nil
+}
+
+// InsertAndStreamBack creates a [WriteCloseAbandoner] used for
+// inserting an object into the cache, as well as a new [Found] that can
+// be used to stream the object back to the caller.
+//
+// Inserting an object into the cache will unblock other transactions
+// waiting on this object, streaming the contents to clients as the data
+// is written.
+//
+// The returned [Found] allows the client inserting a cache object to
+// efficiently read back the contents of that item, avoiding the need to
+// buffer contents for copying to multiple destinations.  This pattern
+// is commonly required when caching an item that also must be provided
+// to, for example, the client response.
+func (t *Transaction) InsertAndStreamBack(opts WriteOptions) (WriteCloseAbandoner, *Found, error) {
+	wopts, err := abiWriteOptions(opts)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	writeBody, abiEntry, err := t.abiEntry.InsertAndStreamBack(wopts)
+	if err != nil {
+		return nil, nil, mapFastlyError(err)
+	}
+
+	newState, err := abiEntry.State()
+	if err != nil {
+		writeBody.Abandon()
+		abiEntry.Close()
+		return nil, nil, mapFastlyError(err)
+	}
+
+	f, err := newFound(t.key, abiEntry, newState, LookupOptions{})
+	if err != nil {
+		writeBody.Abandon()
+		abiEntry.Close()
+		return nil, nil, err
+	}
+
+	return writeBody, f, nil
+}
+
+// Update is used to update a stale object in the cache.
+//
+// Updating an object freshens it by updating its metadata without
+// changing the object itself.
+//
+// This method should only be called when
+// [Transaction.MustInsertOrUpdate] is true and the item is found.
+// Otherwise, an [ErrInvalidOperation] will be returned.
+//
+// NOTE: Updating a cached item will replace ALL of the configuration in
+// the underlying cache object.  If something is not set in the provided
+// [WriteOptions], it will revert to the default value.  This behavior
+// is likely to change in the future to use the existing configuration.
+// This change will be noted in a future changelog.
+//
+// The provided write options must not include request headers, and this
+// will return [ErrInvalidArgument] if they do.
+//
+// This method will return [ErrInvalidOperation] if the object is not
+// stale.
+func (t *Transaction) Update(opts WriteOptions) error {
+	wopts, err := abiWriteOptions(opts)
+	if err != nil {
+		return err
+	}
+
+	err = t.abiEntry.Update(wopts)
+	return mapFastlyError(err)
+}
+
+// Cancel terminates the obligation to provide an object to the cache.
+//
+// If there are concurrent transactional lookups that were blocked
+// waiting on this client to provide the item, one of them will be
+// chosen to be unblocked and given the [Transaction.MustInsertOrUpdate]
+// obligation.
+//
+// Cancel does not close the transaction.  Callers must still call Close
+// to end the transaction and cleanup resources associated with it.
+func (t *Transaction) Cancel() error {
+	return mapFastlyError(t.abiEntry.Cancel())
+}
+
+// Close ends the transaction, commits any inserts or updates, and
+// cleans up resources associated with it.
+//
+// If a Found is associated with this transaction, its Body will be
+// closed if it hasn't been already.
+func (t *Transaction) Close() error {
+	if t.ended {
+		return nil
+	}
+	t.ended = true
+
+	if t.found != nil {
+		t.found.Body.Close()
+	}
+	return t.abiEntry.Close()
+}
+
+type bodyWrapper struct {
+	abiBody *fastly.HTTPBody
+}
+
+func (b *bodyWrapper) Read(p []byte) (int, error) {
+	if b.abiBody == nil {
+		return 0, io.EOF
+	}
+
+	return b.abiBody.Read(p)
+}
+
+func (b *bodyWrapper) Close() error {
+	if b.abiBody == nil {
+		return nil
+	}
+
+	// TODO(joeshaw): currently bodies must be fully drained before they're closed
+	io.Copy(io.Discard, b.abiBody)
+
+	err := b.abiBody.Close()
+	b.abiBody = nil
+	return err
+}
+
+func mapFastlyError(err error) error {
+	status, ok := fastly.IsFastlyError(err)
+	if !ok {
+		return err
+	}
+
+	switch status {
+	case fastly.FastlyStatusNone:
+		return ErrNotFound
+	case fastly.FastlyStatusInval:
+		return ErrInvalidArgument
+	case fastly.FastlyStatusLimitExceeded:
+		return ErrLimitExceeded
+	case fastly.FastlyStatusBadf:
+		return ErrInvalidOperation
+	case fastly.FastlyStatusUnsupported:
+		return ErrUnsupported
+	default:
+		return err
+	}
+}
+
+func ignoreNoneError(err error) error {
+	status, ok := fastly.IsFastlyError(err)
+	if ok && status == fastly.FastlyStatusNone {
+		return nil
+	}
+	return err
+}

--- a/cache/core/core_test.go
+++ b/cache/core/core_test.go
@@ -1,0 +1,156 @@
+package core_test
+
+import (
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/fastly/compute-sdk-go/cache/core"
+)
+
+func ExampleLookup() {
+	// f is a core.Found value, representing a found cache item.
+	// core.ErrNotFound is returned if the item is not cached.
+	f, err := core.Lookup([]byte("my_key"), core.LookupOptions{})
+	if err != nil {
+		panic(err)
+	}
+	defer f.Body.Close()
+
+	// The contents of the cached item are in the Found's Body field.
+	cachedStr, err := io.ReadAll(f.Body)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("The cached value was: %s", cachedStr)
+}
+
+func ExampleInsert() {
+	const (
+		key      = "my_key"
+		contents = "my cached object"
+	)
+
+	// w is a core.WriteCloseAbandoner, a superset of io.WriteCloser.
+	// Data written to this handle is streamed into the Fastly cache.
+	w, err := core.Insert([]byte(key), core.WriteOptions{
+		TTL:           time.Hour,
+		SurrogateKeys: []string{key},
+		Length:        uint64(len(contents)),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	if _, err := io.WriteString(w, contents); err != nil {
+		panic(err)
+	}
+
+	// The writer must be closed to complete the cache operation.
+	// Always check for errors from Close.
+	if err := w.Close(); err != nil {
+		panic(err)
+	}
+}
+
+func ExampleTransaction() {
+	// Users of the transactional API should at a minimum anticipate
+	// lookups that are obligated to insert an object into the cache,
+	// and lookups which are not.  If the stale-while-revalidate
+	// parameter is set for a cached object, the user should also
+	// distinguish between the insertion and revalidation cases.
+
+	useFoundItem := func(f *core.Found) {
+		// Do something with the found item
+	}
+
+	buildContents := func() []byte {
+		// Build the contents of the cached item
+		return []byte("hello world!")
+	}
+
+	shouldReplace := func(f *core.Found, contents []byte) bool {
+		// Determine whether the cached item should be replaced with
+		// the new contents
+		return true
+	}
+
+	tx, err := core.NewTransaction([]byte("my_key"), core.LookupOptions{})
+	if err != nil {
+		panic(err)
+	}
+	defer tx.Close()
+
+	// f is a core.Found value, representing a found cache item.
+	// core.ErrNotFound is returned if the item is not cached.
+	f, err := tx.Found()
+	switch err {
+	case nil:
+		// A cached item was found, though it might be stale.
+		useFoundItem(f)
+
+		// Perform revalidation, if necessary.
+		if tx.MustInsertOrUpdate() {
+			contents := buildContents()
+			if shouldReplace(f, contents) {
+				// Use Insert to replace the previous object
+				w, err := tx.Insert(core.WriteOptions{
+					TTL:           time.Hour,
+					SurrogateKeys: []string{"my_key"},
+					Length:        uint64(len(contents)),
+				})
+				if err != nil {
+					panic(err)
+				}
+
+				if _, err := w.Write(contents); err != nil {
+					panic(err)
+				}
+
+				if err := w.Close(); err != nil {
+					panic(err)
+				}
+			} else {
+				// Otherwise update the stale object's metadata
+				if err := tx.Update(core.WriteOptions{
+					TTL:           time.Hour,
+					SurrogateKeys: []string{"my_key"},
+				}); err != nil {
+					panic(err)
+				}
+			}
+		}
+
+	case core.ErrNotFound:
+		// The item was not found.
+		if tx.MustInsert() {
+			// We've been chosen to insert the object.
+			contents := buildContents()
+			w, f, err := tx.InsertAndStreamBack(core.WriteOptions{
+				TTL:           time.Hour,
+				SurrogateKeys: []string{"my_key"},
+				Length:        uint64(len(contents)),
+			})
+			if err != nil {
+				panic(err)
+			}
+
+			if _, err := w.Write(contents); err != nil {
+				panic(err)
+			}
+
+			if err := w.Close(); err != nil {
+				panic(err)
+			}
+
+			useFoundItem(f)
+		} else {
+			panic(err)
+		}
+
+	default:
+		// An unexpected error
+		panic(err)
+	}
+}

--- a/fsthttp/request.go
+++ b/fsthttp/request.go
@@ -277,9 +277,18 @@ func (req *Request) AddCookie(c *Cookie) {
 	}
 }
 
-// Send the request to the named backend. Requests may only be sent to backends
-// that have been preconfigured in your service, regardless of their URL. Once
-// sent, a request cannot be sent again.
+// Send the request to the named backend. Requests may only be sent to
+// backends that have been preconfigured in your service, regardless of
+// their URL. Once sent, a request cannot be sent again.
+//
+// By default, read-through caching is enabled for requests.  The HTTP
+// response received from the backend will be cached and reused for
+// subsequent requests if it meets cacheability requirements.  The
+// behavior of this automatic caching can be tuned (or disabled) via the
+// [Request]'s [CacheOptions] field.  This function provides the full
+// benefits of Fastly's purging, request collapsing, and revalidation
+// capabilities, and is recommended for most users who need to cache
+// HTTP responses.
 func (req *Request) Send(ctx context.Context, backend string) (*Response, error) {
 	if req.abi.req == nil && req.abi.body == nil {
 		//  abi request not yet constructed

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/fastly/compute-sdk-go
 
-go 1.17
+go 1.18

--- a/internal/abi/fastly/hostcalls_guest.go
+++ b/internal/abi/fastly/hostcalls_guest.go
@@ -11,6 +11,8 @@ import (
 	"io"
 	"math"
 	"net"
+	"strings"
+	"time"
 
 	"github.com/fastly/compute-sdk-go/internal/abi/prim"
 )
@@ -2326,4 +2328,583 @@ func (s *Secret) Plaintext() ([]byte, error) {
 	}
 
 	return buf.AsBytes(), nil
+}
+
+type CacheLookupOptions struct {
+	opts cacheLookupOptions
+	mask cacheLookupOptionsMask
+}
+
+func (o *CacheLookupOptions) SetRequest(req *HTTPRequest) {
+	o.opts.requestHeaders = req.h
+	o.mask |= cacheLookupOptionsMaskRequestHeaders
+}
+
+type CacheGetBodyOptions struct {
+	opts cacheGetBodyOptions
+	mask cacheGetBodyOptionsMask
+}
+
+func (o *CacheGetBodyOptions) From(from uint64) {
+	o.opts.from = prim.U64(from)
+	o.mask |= cacheGetBodyOptionsMaskFrom
+}
+
+func (o *CacheGetBodyOptions) To(to uint64) {
+	o.opts.to = prim.U64(to)
+	o.mask |= cacheGetBodyOptionsMaskTo
+}
+
+type CacheWriteOptions struct {
+	opts cacheWriteOptions
+	mask cacheWriteOptionsMask
+}
+
+func (o *CacheWriteOptions) MaxAge(v time.Duration) {
+	o.opts.maxAgeNs = prim.U64(v.Nanoseconds())
+}
+
+func (o *CacheWriteOptions) SetRequest(req *HTTPRequest) {
+	o.opts.requestHeaders = req.h
+	o.mask |= cacheWriteOptionsMaskRequestHeaders
+}
+
+func (o *CacheWriteOptions) Vary(v []string) {
+	vstr := strings.Join(v, " ")
+	buf := prim.NewReadBufferFromString(vstr)
+	o.opts.varyRulePtr = buf.Char8Pointer()
+	o.opts.varyRuleLen = buf.Len()
+	o.mask |= cacheWriteOptionsMaskVaryRule
+}
+
+func (o *CacheWriteOptions) InitialAge(v time.Duration) {
+	o.opts.initialAgeNs = prim.U64(v.Nanoseconds())
+	o.mask |= cacheWriteOptionsMaskInitialAgeNs
+}
+
+func (o *CacheWriteOptions) StaleWhileRevalidate(v time.Duration) {
+	o.opts.staleWhileRevalidateNs = prim.U64(v.Nanoseconds())
+	o.mask |= cacheWriteOptionsMaskStaleWhileRevalidateNs
+}
+
+func (o *CacheWriteOptions) SurrogateKeys(v []string) {
+	vstr := strings.Join(v, " ")
+	buf := prim.NewReadBufferFromString(vstr)
+	o.opts.surrogateKeysPtr = buf.Char8Pointer()
+	o.opts.surrogateKeysLen = buf.Len()
+	o.mask |= cacheWriteOptionsMaskSurrogateKeys
+}
+
+func (o *CacheWriteOptions) ContentLength(v uint64) {
+	o.opts.length = prim.U64(v)
+	o.mask |= cacheWriteOptionsMaskLength
+}
+
+func (o *CacheWriteOptions) UserMetadata(v []byte) {
+	buf := prim.NewReadBufferFromBytes(v)
+	o.opts.userMetadataPtr = buf.U8Pointer()
+	o.opts.userMetadataLen = buf.Len()
+	o.mask |= cacheWriteOptionsMaskUserMetadata
+}
+
+func (o *CacheWriteOptions) SensitiveData(v bool) {
+	if v {
+		o.mask |= cacheWriteOptionsMaskSensitiveData
+	} else {
+		o.mask &^= cacheWriteOptionsMaskSensitiveData
+	}
+}
+
+type CacheEntry struct {
+	h cacheHandle
+}
+
+// witx:
+//
+//	(module $fastly_cache
+//	  (@interface func (export "lookup")
+//	    (param $cache_key (list u8))
+//	    (param $options_mask $cache_lookup_options_mask)
+//	    (param $options (@witx pointer $cache_lookup_options))
+//	    (result $err (expected $cache_handle (error $fastly_status)))
+//	  )
+//	)
+//
+//go:wasm-module fastly_cache
+//export lookup
+//go:noescape
+func fastlyCacheLookup(
+	key prim.ArrayU8,
+	mask cacheLookupOptionsMask,
+	opts *cacheLookupOptions,
+	h *cacheHandle,
+) FastlyStatus
+
+func CacheLookup(key []byte, opts CacheLookupOptions) (*CacheEntry, error) {
+	var entry CacheEntry
+
+	if err := fastlyCacheLookup(
+		prim.NewReadBufferFromBytes(key).ArrayU8(),
+		opts.mask,
+		&opts.opts,
+		&entry.h,
+	).toError(); err != nil {
+		return nil, err
+	}
+
+	return &entry, nil
+}
+
+// witx:
+//
+//	 ;;; Performs a non-request-collapsing cache insertion (or update).
+//	 ;;;
+//	 ;;; The returned handle is to a streaming body that is used for writing the object into
+//	 ;;; the cache.
+//	 (@interface func (export "insert")
+//		  (param $cache_key (list u8))
+//		  (param $options_mask $cache_write_options_mask)
+//		  (param $options (@witx pointer $cache_write_options))
+//		  (result $err (expected $body_handle (error $fastly_status)))
+//	 )
+//
+//go:wasm-module fastly_cache
+//export insert
+//go:noescape
+func fastlyCacheInsert(
+	key prim.ArrayU8,
+	mask cacheWriteOptionsMask,
+	opts *cacheWriteOptions,
+	h *bodyHandle,
+) FastlyStatus
+
+func CacheInsert(key []byte, opts CacheWriteOptions) (*HTTPBody, error) {
+	body := HTTPBody{closable: true}
+
+	if err := fastlyCacheInsert(
+		prim.NewReadBufferFromBytes(key).ArrayU8(),
+		opts.mask,
+		&opts.opts,
+		&body.h,
+	).toError(); err != nil {
+		return nil, err
+	}
+
+	return &body, nil
+}
+
+// witx:
+//
+//	 ;;; The entrypoint to the request-collapsing cache transaction API.
+//	 ;;;
+//	 ;;; This operation always participates in request collapsing and may return stale objects. To bypass
+//	 ;;; request collapsing, use `lookup` and `insert` instead.
+//	 (@interface func (export "transaction_lookup")
+//		  (param $cache_key (list u8))
+//		  (param $options_mask $cache_lookup_options_mask)
+//		  (param $options (@witx pointer $cache_lookup_options))
+//		  (result $err (expected $cache_handle (error $fastly_status)))
+//	 )
+//
+//go:wasm-module fastly_cache
+//export transaction_lookup
+//go:noescape
+func fastlyCacheTransactionLookup(
+	key prim.ArrayU8,
+	mask cacheLookupOptionsMask,
+	opts *cacheLookupOptions,
+	h *cacheHandle,
+) FastlyStatus
+
+func CacheTransactionLookup(key []byte, opts CacheLookupOptions) (*CacheEntry, error) {
+	var entry CacheEntry
+
+	if err := fastlyCacheTransactionLookup(
+		prim.NewReadBufferFromBytes(key).ArrayU8(),
+		opts.mask,
+		&opts.opts,
+		&entry.h,
+	).toError(); err != nil {
+		return nil, err
+	}
+
+	return &entry, nil
+}
+
+// witx:
+//
+//	;;; Insert an object into the cache with the given metadata.
+//	;;;
+//	;;; Can only be used in if the cache handle state includes the `$must_insert_or_update` flag.
+//	;;;
+//	;;; The returned handle is to a streaming body that is used for writing the object into
+//	;;; the cache.
+//	(@interface func (export "transaction_insert")
+//	  (param $handle $cache_handle)
+//	  (param $options_mask $cache_write_options_mask)
+//	  (param $options (@witx pointer $cache_write_options))
+//	  (result $err (expected $body_handle (error $fastly_status)))
+//	)
+//
+//go:wasm-module fastly_cache
+//export transaction_insert
+//go:noescape
+func fastlyCacheTransactionInsert(
+	h cacheHandle,
+	mask cacheWriteOptionsMask,
+	opts *cacheWriteOptions,
+	body *bodyHandle,
+) FastlyStatus
+
+func (c *CacheEntry) Insert(opts CacheWriteOptions) (*HTTPBody, error) {
+	body := HTTPBody{closable: true}
+
+	if err := fastlyCacheTransactionInsert(
+		c.h,
+		opts.mask,
+		&opts.opts,
+		&body.h,
+	).toError(); err != nil {
+		return nil, err
+	}
+
+	return &body, nil
+}
+
+// witx:
+//
+//	;;; Insert an object into the cache with the given metadata, and return a readable stream of the
+//	;;; bytes as they are stored.
+//	;;;
+//	;;; This helps avoid the "slow reader" problem on a teed stream, for example when a program wishes
+//	;;; to store a backend request in the cache while simultaneously streaming to a client in an HTTP
+//	;;; response.
+//	;;;
+//	;;; The returned body handle is to a streaming body that is used for writing the object _into_
+//	;;; the cache. The returned cache handle provides a separate transaction for reading out the
+//	;;; newly cached object to send elsewhere.
+//	(@interface func (export "transaction_insert_and_stream_back")
+//	  (param $handle $cache_handle)
+//	  (param $options_mask $cache_write_options_mask)
+//	  (param $options (@witx pointer $cache_write_options))
+//	  (result $err (expected (tuple $body_handle $cache_handle) (error $fastly_status)))
+//	)
+//
+//go:wasm-module fastly_cache
+//export transaction_insert_and_stream_back
+//go:noescape
+func fastlyCacheTransactionInsertAndStreamBack(
+	h cacheHandle,
+	mask cacheWriteOptionsMask,
+	opts *cacheWriteOptions,
+	body *bodyHandle,
+	stream *cacheHandle,
+) FastlyStatus
+
+func (c *CacheEntry) InsertAndStreamBack(opts CacheWriteOptions) (*HTTPBody, *CacheEntry, error) {
+	var entry CacheEntry
+	body := HTTPBody{closable: true}
+
+	if err := fastlyCacheTransactionInsertAndStreamBack(
+		c.h,
+		opts.mask,
+		&opts.opts,
+		&body.h,
+		&entry.h,
+	).toError(); err != nil {
+		return nil, nil, err
+	}
+
+	return &body, &entry, nil
+}
+
+// witx:
+//
+//	;;; Update the metadata of an object in the cache without changing its data.
+//	;;;
+//	;;; Can only be used in if the cache handle state includes both of the flags:
+//	;;; - `$found`
+//	;;; - `$must_insert_or_update`
+//	(@interface func (export "transaction_update")
+//	  (param $handle $cache_handle)
+//	  (param $options_mask $cache_write_options_mask)
+//	  (param $options (@witx pointer $cache_write_options))
+//	  (result $err (expected (error $fastly_status)))
+//	)
+//
+//go:wasm-module fastly_cache
+//export transaction_update
+//go:noescape
+func fastlyCacheTransactionUpdate(
+	h cacheHandle,
+	mask cacheWriteOptionsMask,
+	opts *cacheWriteOptions,
+) FastlyStatus
+
+func (c *CacheEntry) Update(opts CacheWriteOptions) error {
+	return fastlyCacheTransactionUpdate(
+		c.h,
+		opts.mask,
+		&opts.opts,
+	).toError()
+}
+
+// witx:
+//
+//	 ;;; Cancel an obligation to provide an object to the cache.
+//	 ;;;
+//	 ;;; Useful if there is an error before streaming is possible, e.g. if a backend is unreachable.
+//	 (@interface func (export "transaction_cancel")
+//		  (param $handle $cache_handle)
+//		  (result $err (expected (error $fastly_status)))
+//	 )
+//
+//go:wasm-module fastly_cache
+//export transaction_cancel
+//go:noescape
+func fastlyCacheTransactionCancel(h cacheHandle) FastlyStatus
+
+func (c *CacheEntry) Cancel() error {
+	return fastlyCacheTransactionCancel(c.h).toError()
+}
+
+// witx:
+//
+//	(@interface func (export "close")
+//	  (param $handle $cache_handle)
+//	  (result $err (expected (error $fastly_status)))
+//	)
+//
+//go:wasm-module fastly_cache
+//export close
+//go:noescape
+func fastlyCacheClose(h cacheHandle) FastlyStatus
+
+func (c *CacheEntry) Close() error {
+	return fastlyCacheClose(c.h).toError()
+}
+
+// witx:
+//
+//	(@interface func (export "get_state")
+//	  (param $handle $cache_handle)
+//	  (result $err (expected $cache_lookup_state (error $fastly_status)))
+//	)
+//
+//go:wasm-module fastly_cache
+//export get_state
+//go:noescape
+func fastlyCacheGetState(h cacheHandle, st *CacheLookupState) FastlyStatus
+
+func (c *CacheEntry) State() (CacheLookupState, error) {
+	var state CacheLookupState
+	if err := fastlyCacheGetState(c.h, &state).toError(); err != nil {
+		return 0, err
+	}
+
+	return state, nil
+}
+
+// witx:
+//
+//	 ;;; Gets the user metadata of the found object, returning the `$none` error if there
+//	 ;;; was no found object.
+//	 (@interface func (export "get_user_metadata")
+//		  (param $handle $cache_handle)
+//		  (param $user_metadata_out_ptr (@witx pointer u8))
+//		  (param $user_metadata_out_len (@witx usize))
+//		  (param $nwritten_out (@witx pointer (@witx usize)))
+//		  (result $err (expected (error $fastly_status)))
+//	 )
+//
+//go:wasm-module fastly_cache
+//export get_user_metadata
+//go:noescape
+func fastlyCacheGetUserMetadata(
+	h cacheHandle,
+	buf *prim.U8,
+	bufLen prim.Usize,
+	nwritten *prim.Usize,
+) FastlyStatus
+
+func (c *CacheEntry) UserMetadata() ([]byte, error) {
+	buf := prim.NewWriteBuffer(defaultBufferLen)
+
+	status := fastlyCacheGetUserMetadata(
+		c.h,
+		buf.U8Pointer(),
+		buf.Cap(),
+		buf.NPointer(),
+	)
+	if status == FastlyStatusBufLen {
+		// The buffer was too small, but it'll tell us how big it will
+		// need to be in order to fit the content.
+		buf = prim.NewWriteBuffer(int(buf.NValue()))
+
+		status = fastlyCacheGetUserMetadata(
+			c.h,
+			buf.U8Pointer(),
+			buf.Cap(),
+			buf.NPointer(),
+		)
+	}
+
+	if err := status.toError(); err != nil {
+		return nil, err
+	}
+
+	return buf.AsBytes(), nil
+}
+
+// witx:
+//
+//	 ;;; Gets a range of the found object body, returning the `$none` error if there
+//	 ;;; was no found object.
+//	 (@interface func (export "get_body")
+//	   (param $handle $cache_handle)
+//		  (param $options_mask $cache_get_body_options_mask)
+//		  (param $options $cache_get_body_options)
+//		  (result $err (expected $body_handle (error $fastly_status)))
+//	 )
+//
+//go:wasm-module fastly_cache
+//export get_body
+//go:noescape
+func fastlyCacheGetBody(
+	h cacheHandle,
+	mask cacheGetBodyOptionsMask,
+	opts *cacheGetBodyOptions,
+	body *bodyHandle,
+) FastlyStatus
+
+func (c *CacheEntry) Body(opts CacheGetBodyOptions) (*HTTPBody, error) {
+	var b HTTPBody
+
+	if err := fastlyCacheGetBody(
+		c.h,
+		opts.mask,
+		&opts.opts,
+		&b.h,
+	).toError(); err != nil {
+		return nil, err
+	}
+
+	b.closable = true
+
+	return &b, nil
+}
+
+// witx:
+//
+//	 ;;; Gets the content length of the found object, returning the `$none` error if there
+//	 ;;; was no found object, or no content length was provided.
+//	 (@interface func (export "get_length")
+//		  (param $handle $cache_handle)
+//		  (result $err (expected $cache_object_length (error $fastly_status)))
+//	 )
+//
+//go:wasm-module fastly_cache
+//export get_length
+//go:noescape
+func fastlyCacheGetLength(h cacheHandle, l *prim.U64) FastlyStatus
+
+func (c *CacheEntry) Length() (uint64, error) {
+	var l prim.U64
+	if err := fastlyCacheGetLength(c.h, &l).toError(); err != nil {
+		return 0, err
+	}
+
+	return uint64(l), nil
+}
+
+// witx:
+//
+//	 ;;; Gets the configured max age of the found object, returning the `$none` error if there
+//	 ;;; was no found object.
+//	 (@interface func (export "get_max_age_ns")
+//		  (param $handle $cache_handle)
+//		  (result $err (expected $cache_duration_ns (error $fastly_status)))
+//	 )
+//
+//go:wasm-module fastly_cache
+//export get_max_age_ns
+//go:noescape
+func fastlyCacheGetMaxAgeNs(h cacheHandle, d *prim.U64) FastlyStatus
+
+func (c *CacheEntry) MaxAge() (time.Duration, error) {
+	var d prim.U64
+	if err := fastlyCacheGetMaxAgeNs(c.h, &d).toError(); err != nil {
+		return 0, err
+	}
+
+	return time.Duration(d), nil
+}
+
+// witx:
+//
+//	 ;;; Gets the configured stale-while-revalidate period of the found object, returning the
+//	 ;;; `$none` error if there was no found object.
+//	 (@interface func (export "get_stale_while_revalidate_ns")
+//		  (param $handle $cache_handle)
+//		  (result $err (expected $cache_duration_ns (error $fastly_status)))
+//	 )
+//
+//go:wasm-module fastly_cache
+//export get_stale_while_revalidate_ns
+//go:noescape
+func fastlyCacheGetStaleWhileRevalidateNs(h cacheHandle, d *prim.U64) FastlyStatus
+
+func (c *CacheEntry) StaleWhileRevalidate() (time.Duration, error) {
+	var d prim.U64
+	if err := fastlyCacheGetStaleWhileRevalidateNs(c.h, &d).toError(); err != nil {
+		return 0, err
+	}
+
+	return time.Duration(d), nil
+}
+
+// witx:
+//
+//	 ;;; Gets the age of the found object, returning the `$none` error if there
+//	 ;;; was no found object.
+//	 (@interface func (export "get_age_ns")
+//		  (param $handle $cache_handle)
+//		  (result $err (expected $cache_duration_ns (error $fastly_status)))
+//	 )
+//
+//go:wasm-module fastly_cache
+//export get_age_ns
+//go:noescape
+func fastlyCacheGetAgeNs(h cacheHandle, d *prim.U64) FastlyStatus
+
+func (c *CacheEntry) Age() (time.Duration, error) {
+	var d prim.U64
+	if err := fastlyCacheGetAgeNs(c.h, &d).toError(); err != nil {
+		return 0, err
+	}
+
+	return time.Duration(d), nil
+}
+
+// witx:
+//
+//	 ;;; Gets the number of cache hits for the found object, returning the `$none` error if there
+//	 ;;; was no found object.
+//	 (@interface func (export "get_hits")
+//		  (param $handle $cache_handle)
+//		  (result $err (expected $cache_hit_count (error $fastly_status)))
+//	 )
+//
+//go:wasm-module fastly_cache
+//export get_hits
+//go:noescape
+func fastlyCacheGetHits(h cacheHandle, d *prim.U64) FastlyStatus
+
+func (c *CacheEntry) Hits() (uint64, error) {
+	var d prim.U64
+	if err := fastlyCacheGetHits(c.h, &d).toError(); err != nil {
+		return 0, err
+	}
+
+	return uint64(d), nil
 }

--- a/internal/abi/fastly/hostcalls_noguest.go
+++ b/internal/abi/fastly/hostcalls_noguest.go
@@ -39,6 +39,10 @@ func (b *HTTPBody) Close() error {
 	return fmt.Errorf("not implemented")
 }
 
+func (b *HTTPBody) Abandon() error {
+	return fmt.Errorf("not implemented")
+}
+
 type LogEndpoint struct{}
 
 func GetLogEndpoint(name string) (*LogEndpoint, error) {

--- a/internal/abi/fastly/hostcalls_noguest.go
+++ b/internal/abi/fastly/hostcalls_noguest.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"net"
+	"time"
 )
 
 func ParseUserAgent(userAgent string) (family, major, minor, patch string, err error) {
@@ -278,4 +279,123 @@ func (s *SecretStore) Get(name string) (*Secret, error) {
 
 func (s *Secret) Plaintext() ([]byte, error) {
 	return nil, fmt.Errorf("not implemented")
+}
+
+type (
+	CacheEntry          struct{}
+	CacheLookupOptions  struct{}
+	CacheGetBodyOptions struct{}
+	CacheWriteOptions   struct{}
+)
+
+func (o *CacheLookupOptions) SetRequest(req *HTTPRequest) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (o *CacheGetBodyOptions) From(from uint64) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (o *CacheGetBodyOptions) To(to uint64) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (o *CacheWriteOptions) MaxAge(v time.Duration) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (o *CacheWriteOptions) SetRequest(req *HTTPRequest) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (o *CacheWriteOptions) Vary(v []string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (o *CacheWriteOptions) InitialAge(v time.Duration) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (o *CacheWriteOptions) StaleWhileRevalidate(v time.Duration) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (o *CacheWriteOptions) SurrogateKeys(v []string) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (o *CacheWriteOptions) ContentLength(v uint64) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (o *CacheWriteOptions) UserMetadata(v []byte) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (o *CacheWriteOptions) SensitiveData(v bool) error {
+	return fmt.Errorf("not implemented")
+}
+
+func CacheLookup(key []byte, opts CacheLookupOptions) (*CacheEntry, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func CacheInsert(key []byte, opts CacheWriteOptions) (*HTTPBody, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func CacheTransactionLookup(key []byte, opts CacheLookupOptions) (*CacheEntry, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (e *CacheEntry) Insert(opts CacheWriteOptions) (*HTTPBody, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (e *CacheEntry) InsertAndStreamBack(opts CacheWriteOptions) (*HTTPBody, *CacheEntry, error) {
+	return nil, nil, fmt.Errorf("not implemented")
+}
+
+func (e *CacheEntry) Update(opts CacheWriteOptions) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (e *CacheEntry) Cancel() error {
+	return fmt.Errorf("not implemented")
+}
+
+func (c *CacheEntry) Close() error {
+	return fmt.Errorf("not implemented")
+}
+
+func (c *CacheEntry) State() (CacheLookupState, error) {
+	return 0, fmt.Errorf("not implemented")
+}
+
+func (c *CacheEntry) UserMetadata() ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (c *CacheEntry) Body(opts CacheGetBodyOptions) (*HTTPBody, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (c *CacheEntry) Length() (uint64, error) {
+	return 0, fmt.Errorf("not implemented")
+}
+
+func (c *CacheEntry) MaxAge() (time.Duration, error) {
+	return 0, fmt.Errorf("not implemented")
+}
+
+func (c *CacheEntry) StaleWhileRevalidate() (time.Duration, error) {
+	return 0, fmt.Errorf("not implemented")
+}
+
+func (c *CacheEntry) Age() (time.Duration, error) {
+	return 0, fmt.Errorf("not implemented")
+}
+
+func (c *CacheEntry) Hits() (uint64, error) {
+	return 0, fmt.Errorf("not implemented")
 }

--- a/internal/abi/fastly/hostcalls_noguest.go
+++ b/internal/abi/fastly/hostcalls_noguest.go
@@ -399,3 +399,13 @@ func (c *CacheEntry) Age() (time.Duration, error) {
 func (c *CacheEntry) Hits() (uint64, error) {
 	return 0, fmt.Errorf("not implemented")
 }
+
+type PurgeOptions struct{}
+
+func (o *PurgeOptions) SoftPurge(v bool) error {
+	return fmt.Errorf("not implemented")
+}
+
+func PurgeSurrogateKey(surrogateKey string, opts PurgeOptions) error {
+	return fmt.Errorf("not implemented")
+}

--- a/internal/abi/fastly/types.go
+++ b/internal/abi/fastly/types.go
@@ -33,7 +33,8 @@ type FastlyStatus uint32
 //          $httpincomplete
 //          $none
 //          $httpheadtoolarge
-//          $httpinvalidstatus))
+//          $httpinvalidstatus
+//          $limitexceeded))
 
 const (
 	// FastlyStatusOK maps to $fastly_status $ok.
@@ -75,6 +76,9 @@ const (
 
 	// FastlyStatusHTTPInvalidStatus maps to $fastly_status $httpinvalidstatus.
 	FastlyStatusHTTPInvalidStatus FastlyStatus = 12
+
+	// FastlyStatusLimitExceeded maps to $fastly_status $limitexceeded.
+	FastlyStatusLimitExceeded FastlyStatus = 13
 )
 
 // String implements fmt.Stringer.
@@ -106,8 +110,10 @@ func (s FastlyStatus) String() string {
 		return "HTTPHeadTooLarge"
 	case FastlyStatusHTTPInvalidStatus:
 		return "HTTPInvalidStatus"
+	case FastlyStatusLimitExceeded:
+		return "LimitExceeded"
 	default:
-		return "unknown"
+		return fmt.Sprintf("FastlyStatus(%d)", s)
 	}
 }
 

--- a/internal/abi/fastly/types.go
+++ b/internal/abi/fastly/types.go
@@ -269,7 +269,6 @@ func (r multiValueCursorResult) toCursor() multiValueCursor { return multiValueC
 //
 //	 (typename $cache_override_tag
 //		(flags u32
-//		  $none
 //		  $pass
 //		  $ttl
 //		  $stale_while_revalidate
@@ -277,7 +276,7 @@ func (r multiValueCursorResult) toCursor() multiValueCursor { return multiValueC
 type cacheOverrideTag uint32
 
 const (
-	cacheOverrideTagNone                 cacheOverrideTag = 0b0000_0000 // $none
+	cacheOverrideTagNone                 cacheOverrideTag = 0b0000_0000
 	cacheOverrideTagPass                 cacheOverrideTag = 0b0000_0001 // $pass
 	cacheOverrideTagTTL                  cacheOverrideTag = 0b0000_0010 // $ttl
 	cacheOverrideTagStaleWhileRevalidate cacheOverrideTag = 0b0000_0100 // $stale_while_revalidate

--- a/internal/abi/fastly/types.go
+++ b/internal/abi/fastly/types.go
@@ -639,3 +639,34 @@ const (
 	CacheLookupStateStale              CacheLookupState = 0b0000_0100 // $stale
 	CacheLookupStateMustInsertOrUpdate CacheLookupState = 0b0000_1000 // $must_insert_or_update
 )
+
+// witx:
+//
+//	(typename $purge_options_mask
+//	    (flags (@witx repr u32)
+//	        $soft_purge
+//	        $ret_buf ;; all ret_buf fields must be populated
+//	    )
+//	)
+type purgeOptionsMask prim.U32
+
+const (
+	purgeOptionsMaskSoftPurge purgeOptionsMask = 1 << 0 // $soft_purge
+	purgeOptionsMaskRetBuf    purgeOptionsMask = 1 << 1 // $ret_buf
+)
+
+// witx:
+//
+//	(typename $purge_options
+//	    (record
+//	        ;; JSON purge response as in https://developer.fastly.com/reference/api/purging/#purge-tag
+//	        (field $ret_buf_ptr (@witx pointer u8))
+//	        (field $ret_buf_len (@witx usize))
+//	        (field $ret_buf_nwritten_out (@witx pointer (@witx usize)))
+//	    )
+//	)
+type purgeOptions struct {
+	retBufPtr         *prim.U8
+	retBufLen         prim.Usize
+	retBufNwrittenOut *prim.Usize
+}

--- a/internal/abi/fastly/types.go
+++ b/internal/abi/fastly/types.go
@@ -481,3 +481,161 @@ type (
 	secretStoreHandle handle
 	secretHandle      handle
 )
+
+// witx:
+//
+//	;;; The outcome of a cache lookup (either bare or as part of a cache transaction)
+//	(typename $cache_handle (handle))
+type cacheHandle handle
+
+// witx:
+//
+//	;;; Extensible options for cache lookup operations; currently used for both `lookup` and `transaction_lookup`.
+//	(typename $cache_lookup_options
+//	    (record
+//	        (field $request_headers $request_handle) ;; a full request handle, but used only for its headers
+//	    )
+//	)
+type cacheLookupOptions struct {
+	requestHeaders requestHandle
+}
+
+// witx:
+//
+//	(typename $cache_lookup_options_mask
+//	    (flags (@witx repr u32)
+//	        $reserved
+//	        $request_headers
+//	    )
+//	)
+type cacheLookupOptionsMask prim.U32
+
+const (
+	cacheLookupOptionsMaskReserved       cacheLookupOptionsMask = 0b0000_0001 // $reserved
+	cacheLookupOptionsMaskRequestHeaders cacheLookupOptionsMask = 0b0000_0010 // $request_headers
+)
+
+// witx:
+//
+//	(typename $cache_object_length u64)
+//	(typename $cache_duration_ns u64)
+//	(typename $cache_hit_count u64)
+//
+//	;;; Configuration for several hostcalls that write to the cache:
+//	;;; - `insert`
+//	;;; - `transaction_insert`
+//	;;; - `transaction_insert_and_stream_back`
+//	;;; - `transaction_update`
+//	;;;
+//	;;; Some options are only allowed for certain of these hostcalls; see `cache_write_options_mask`.
+//	(typename $cache_write_options
+//	    (record
+//	        (field $max_age_ns $cache_duration_ns) ;; this is a required field; there's no flag for it
+//	        (field $request_headers $request_handle) ;; a full request handle, but used only for its headers
+//	        (field $vary_rule_ptr (@witx pointer (@witx char8))) ;; a list of header names separated by spaces
+//	        (field $vary_rule_len (@witx usize))
+//	        ;; The initial age of the object in nanoseconds (default: 0).
+//	        ;;
+//	        ;; This age is used to determine the freshness lifetime of the object as well as to
+//	        ;; prioritize which variant to return if a subsequent lookup matches more than one vary rule
+//	        (field $initial_age_ns $cache_duration_ns)
+//	        (field $stale_while_revalidate_ns $cache_duration_ns)
+//	        (field $surrogate_keys_ptr (@witx pointer (@witx char8))) ;; a list of surrogate keys separated by spaces
+//	        (field $surrogate_keys_len (@witx usize))
+//	        (field $length $cache_object_length)
+//	        (field $user_metadata_ptr (@witx pointer (@witx u8)))
+//	        (field $user_metadata_len (@witx usize))
+//	    )
+//	)
+type cacheWriteOptions struct {
+	maxAgeNs               prim.U64
+	requestHeaders         requestHandle
+	varyRulePtr            *prim.Char8
+	varyRuleLen            prim.Usize
+	initialAgeNs           prim.U64
+	staleWhileRevalidateNs prim.U64
+	surrogateKeysPtr       *prim.Char8
+	surrogateKeysLen       prim.Usize
+	length                 prim.U64
+	userMetadataPtr        *prim.U8
+	userMetadataLen        prim.Usize
+}
+
+// witx:
+//
+//	(typename $cache_write_options_mask
+//	    (flags (@witx repr u32)
+//	        $reserved
+//	        $request_headers ;;; Only allowed for non-transactional `insert`
+//	        $vary_rule
+//	        $initial_age_ns
+//	        $stale_while_revalidate_ns
+//	        $surrogate_keys
+//	        $length
+//	        $user_metadata
+//	        $sensitive_data
+//	    )
+//	)
+type cacheWriteOptionsMask prim.U32
+
+const (
+	cacheWriteOptionsMaskReserved               cacheWriteOptionsMask = 1 << 0 // $reserved
+	cacheWriteOptionsMaskRequestHeaders         cacheWriteOptionsMask = 1 << 1 // $request_headers
+	cacheWriteOptionsMaskVaryRule               cacheWriteOptionsMask = 1 << 2 // $vary_rule
+	cacheWriteOptionsMaskInitialAgeNs           cacheWriteOptionsMask = 1 << 3 // $initial_age_ns
+	cacheWriteOptionsMaskStaleWhileRevalidateNs cacheWriteOptionsMask = 1 << 4 // $stale_while_revalidate_ns
+	cacheWriteOptionsMaskSurrogateKeys          cacheWriteOptionsMask = 1 << 5 // $surrogate_keys
+	cacheWriteOptionsMaskLength                 cacheWriteOptionsMask = 1 << 6 // $length
+	cacheWriteOptionsMaskUserMetadata           cacheWriteOptionsMask = 1 << 7 // $user_metadata
+	cacheWriteOptionsMaskSensitiveData          cacheWriteOptionsMask = 1 << 8 // $sensitive_data
+)
+
+// witx:
+//
+//	(typename $cache_get_body_options
+//	    (record
+//	        (field $from u64)
+//	        (field $to u64)
+//	    )
+//	)
+type cacheGetBodyOptions struct {
+	from prim.U64
+	to   prim.U64
+}
+
+// witx:
+//
+//	(typename $cache_get_body_options_mask
+//	    (flags (@witx repr u32)
+//	        $reserved
+//	        $from
+//	        $to
+//	    )
+//	)
+type cacheGetBodyOptionsMask prim.U32
+
+const (
+	cacheGetBodyOptionsMaskReserved cacheGetBodyOptionsMask = 0b0000_0001 // $reserved
+	cacheGetBodyOptionsMaskFrom     cacheGetBodyOptionsMask = 0b0000_0010 // $from
+	cacheGetBodyOptionsMaskTo       cacheGetBodyOptionsMask = 0b0000_0100 // $to
+)
+
+// witx:
+//
+//	;;; The status of this lookup (and potential transaction)
+//	(typename $cache_lookup_state
+//	    (flags (@witx repr u32)
+//	        $found ;; a cached object was found
+//	        $usable ;; the cached object is valid to use (implies $found)
+//	        $stale ;; the cached object is stale (but may or may not be valid to use)
+//	        $must_insert_or_update ;; this client is requested to insert or revalidate an object
+//	    )
+//	)
+type CacheLookupState prim.U32
+
+const (
+	CacheLookupStateFound              CacheLookupState = 0b0000_0001 // $found
+	CacheLookupStateUsable             CacheLookupState = 0b0000_0010 // $usable
+	CacheLookupStateStale              CacheLookupState = 0b0000_0100 // $stale
+	CacheLookupStateMustInsertOrUpdate CacheLookupState = 0b0000_1000 // $must_insert_or_update
+)

--- a/internal/abi/prim/prim.go
+++ b/internal/abi/prim/prim.go
@@ -74,7 +74,7 @@ func (b *WriteBuffer) Char8Pointer() *Char8 {
 	return (*Char8)(unsafe.Pointer(b.hdr.Data))
 }
 
-// U8Pointer returns a pointer to the buffer's data as a Char8.
+// U8Pointer returns a pointer to the buffer's data as a U8.
 func (b *WriteBuffer) U8Pointer() *U8 {
 	return (*U8)(unsafe.Pointer(b.hdr.Data))
 }
@@ -158,6 +158,11 @@ func (b *ReadBuffer) ArrayChar8() ArrayChar8 {
 // Char8Pointer returns a pointer to the buffer's data as a Char8.
 func (b *ReadBuffer) Char8Pointer() *Char8 {
 	return (*Char8)(unsafe.Pointer(b.hdr.Data))
+}
+
+// U8Pointer returns a pointer to the buffer's data as a U8.
+func (b *ReadBuffer) U8Pointer() *U8 {
+	return (*U8)(unsafe.Pointer(b.hdr.Data))
 }
 
 // Len returns the length of data in the buffer as a Usize.

--- a/purge/purge.go
+++ b/purge/purge.go
@@ -1,0 +1,25 @@
+// Package purge provides cache purging operations for Fastly
+// Compute@Edge.
+//
+// See the [Fastly purge documentation] for details.
+//
+// [Fastly purge documentation]: https://developer.fastly.com/learning/concepts/purging/
+package purge
+
+import "github.com/fastly/compute-sdk-go/internal/abi/fastly"
+
+// PurgeOptions control the behavior of purge operations.
+type PurgeOptions struct {
+	// Whether to soft purge the item.  A soft purge marks a cached
+	// object as stale, rather than invalidating it.
+	Soft bool
+}
+
+// PurgeSurrogateKey purges all cached objects with the provided
+// surrogate key.
+func PurgeSurrogateKey(surrogateKey string, opts PurgeOptions) error {
+	var abiOpts fastly.PurgeOptions
+	abiOpts.SoftPurge(opts.Soft)
+
+	return fastly.PurgeSurrogateKey(surrogateKey, abiOpts)
+}


### PR DESCRIPTION
The Core Cache API (in the `cache/core` package) exposes the primitive operations required to implement high-performance cache applications with advanced features such as request collapsing, streaming miss, revalidation and surrogate key purging.

While this API contains affordances for some HTTP caching concepts such as Vary headers and stale-while-revalidate, this API is not suitable for HTTP caching out-of-the-box.  Future SDK releases will add a more customizable HTTP Cache API with support for customizable read-through caching, freshness lifetime inference, conditional request evaluation, automatic revalidation, and more.

In the simplest cases, the top-level `Insert` and `Lookup` functions are used for one-off operations on a cached object, and are appropriate when request collapsing and revalidation capabilities are not required. The API also supports more complex uses via `Transaction`, which can collapse concurrent lookups to the same item, including coordinating revalidation.

Example uses of this API are included in `_examples/corecache` and in `cache/core/core_test.go`.

This PR also adds support for surrogate key purging in the `purge` package.

Other minor tweaks:
* Bumps the minimum Go version to 1.18
* Adds the `Abandon` hostcall to `fastly.HTTPBody`, which is important for the core cache API
* Adds the `LimitExceeded` `FastlyStatus` (Closes #46)
* Fixes an off-by-one error in the comment witx for cache_override_tag