### PR TITLE
Improve errors on failure

### DIFF
--- a/fsthttp/backend.go
+++ b/fsthttp/backend.go
@@ -12,8 +12,8 @@ var (
 	// create dynamic backends.
 	ErrDynamicBackendDisallowed = errors.New("dynamic backends not supported for this service")
 
-	// ErrDynamicBackendNameInUse indicates the backend name is already in use.
-	ErrDynamicBackendNameInUse = errors.New("backend name already in use")
+	// ErrBackendNameInUse indicates the backend name is already in use.
+	ErrBackendNameInUse = errors.New("backend name already in use")
 )
 
 type TLSVersion uint32
@@ -128,7 +128,7 @@ func RegisterDynamicBackend(name string, target string, options *BackendOptions)
 		case ok && status == fastly.FastlyStatusUnsupported:
 			return nil, ErrDynamicBackendDisallowed
 		case ok && status == fastly.FastlyStatusError:
-			return nil, ErrDynamicBackendNameInUse
+			return nil, ErrBackendNameInUse
 		default:
 			return nil, err
 		}

--- a/fsthttp/backend.go
+++ b/fsthttp/backend.go
@@ -1,9 +1,19 @@
 package fsthttp
 
 import (
+	"errors"
 	"time"
 
 	"github.com/fastly/compute-sdk-go/internal/abi/fastly"
+)
+
+var (
+	// ErrDynamicBackendDisallowed indicates the service is not allowed to
+	// create dynamic backends.
+	ErrDynamicBackendDisallowed = errors.New("dynamic backends not supported for this service")
+
+	// ErrDynamicBackendNameInUse indicates the backend name is already in use.
+	ErrDynamicBackendNameInUse = errors.New("backend name already in use")
 )
 
 type TLSVersion uint32
@@ -111,9 +121,21 @@ func RegisterDynamicBackend(name string, target string, options *BackendOptions)
 	} else {
 		abiOpts = &fastly.BackendConfigOptions{}
 	}
+	err := fastly.RegisterDynamicBackend(name, target, abiOpts)
+	if err != nil {
+		status, ok := fastly.IsFastlyError(err)
+		switch {
+		case ok && status == fastly.FastlyStatusUnsupported:
+			return nil, ErrDynamicBackendDisallowed
+		case ok && status == fastly.FastlyStatusError:
+			return nil, ErrDynamicBackendNameInUse
+		default:
+			return nil, err
+		}
+	}
 	b := Backend{
 		name:   name,
 		target: target,
 	}
-	return &b, fastly.RegisterDynamicBackend(name, target, abiOpts)
+	return &b, nil
 }


### PR DESCRIPTION
The error names are longish, happy to go for something shorter.

We should probably add other errors, e.g., https://docs.rs/fastly/0.9.4/src/fastly/backend/builder.rs.html#231, but I'd leave that for another PR.