### PR TITLE
test: add kvstore basic test app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_integration_tests/fixtures/kvstore/bin/main.wasm
+_integration_tests/fixtures/kvstore/pkg/kvstore.tar.gz

--- a/_integration_tests/fixtures/kvstore/fastly.toml
+++ b/_integration_tests/fixtures/kvstore/fastly.toml
@@ -1,0 +1,17 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["jchampion@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 3
+name = "kvstore"
+service_id = ""
+
+[local_server]
+
+  [local_server.kv_stores]
+
+  [[local_server.kv_stores.example-test-kv-store]]
+  key = "hello"
+  data = "world"

--- a/_integration_tests/fixtures/kvstore/main.go
+++ b/_integration_tests/fixtures/kvstore/main.go
@@ -1,0 +1,52 @@
+// Copyright 2022 Fastly, Inc.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/fastly/compute-sdk-go/fsthttp"
+	"github.com/fastly/compute-sdk-go/kvstore"
+)
+
+func main() {
+	fsthttp.ServeFunc(func(ctx context.Context, res fsthttp.ResponseWriter, req *fsthttp.Request) {
+		store, err := kvstore.Open("example-test-kv-store")
+		if err != nil {
+			fsthttp.Error(res, err.Error(), fsthttp.StatusInternalServerError)
+			return
+		}
+
+		switch req.URL.Path {
+		case "/lookup":
+			{
+				hello, err := store.Lookup("hello")
+				if err != nil {
+					fsthttp.Error(res, err.Error(), fsthttp.StatusInternalServerError)
+					return
+				}
+
+				fmt.Fprint(res, hello.String())
+			}
+		case "/insert":
+			{
+				err := store.Insert("animal", strings.NewReader("cat"))
+				if err != nil {
+					fsthttp.Error(res, err.Error(), fsthttp.StatusInternalServerError)
+					return
+				}
+
+				animal, err := store.Lookup("animal")
+				if err != nil {
+					fsthttp.Error(res, err.Error(), fsthttp.StatusInternalServerError)
+					return
+				}
+
+				fmt.Fprint(res, animal.String())
+			}
+		}
+
+	})
+}

--- a/_integration_tests/fixtures/kvstore/main.go
+++ b/_integration_tests/fixtures/kvstore/main.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Fastly, Inc.
+// Copyright 2023 Fastly, Inc.
 
 package main
 

--- a/_integration_tests/sdk-test-config.json
+++ b/_integration_tests/sdk-test-config.json
@@ -119,6 +119,37 @@
       }
     },
 
+    "kvstore" : {
+      "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -o ./_integration_tests/fixtures/kvstore/kvstore.wasm ./_integration_tests/fixtures/kvstore && (cd ./_integration_tests/fixtures/kvstore && fastly compute pack --verbose --wasm-binary ./kvstore.wasm)",
+      "fastly_toml_path": "./_integration_tests/fixtures/kvstore/fastly.toml",
+      "wasm_path": "./_integration_tests/fixtures/kvstore/kvstore.wasm",
+      "pkg_path": "./_integration_tests/fixtures/kvstore/pkg/kvstore.tar.gz",
+      "tests": {
+        "GET /lookup": {
+          "environments": ["viceroy"],
+          "downstream_request": {
+            "method": "GET",
+            "pathname": "/lookup"
+          },
+          "downstream_response": {
+            "status": 200,
+            "body": "world"
+          }
+        },
+        "GET /insert": {
+          "environments": ["viceroy"],
+          "downstream_request": {
+            "method": "GET",
+            "pathname": "/insert"
+          },
+          "downstream_response": {
+            "status": 200,
+            "body": "cat"
+          }
+        }
+      }
+    },
+
     "request_upstream" : {
       "build": "tinygo build -target=wasi -scheduler=asyncify -gc=leaking -o ./_integration_tests/fixtures/request_upstream/request_upstream.wasm ./_integration_tests/fixtures/request_upstream && (cd ./_integration_tests/fixtures/request_upstream && fastly compute pack --verbose --wasm-binary ./request_upstream.wasm)",
       "fastly_toml_path": "./_integration_tests/fixtures/request_upstream/fastly.toml",


### PR DESCRIPTION
This adds an integration test to show that the happy-paths for kvstore open, insert, and lookup methods work as expected