### PR TITLE
fix a handful of backend bugs

### DIFF
--- a/internal/abi/fastly/hostcalls_guest.go
+++ b/internal/abi/fastly/hostcalls_guest.go
@@ -1613,15 +1613,15 @@ func BackendExists(name string) (bool, error) {
 //go:noescape
 func fastlyBackendIsHealthy(name prim.Wstring, healthy *prim.U32) FastlyStatus
 
-func BackendIsHealthy(name string) (bool, error) {
-	var healthy prim.U32
+func BackendIsHealthy(name string) (BackendHealth, error) {
+	var health prim.U32
 	if err := fastlyBackendIsHealthy(
 		prim.NewReadBufferFromString(name).Wstring(),
-		&healthy,
+		&health,
 	).toError(); err != nil {
-		return false, err
+		return BackendHealthUnknown, err
 	}
-	return healthy != 0, nil
+	return BackendHealth(health), nil
 }
 
 // witx:
@@ -1853,7 +1853,7 @@ func BackendIsSSL(name string) (bool, error) {
 //	)
 //
 //go:wasm-module fastly_backend
-//export get_port
+//export get_ssl_min_version
 //go:noescape
 func fastlyBackendGetSSLMinVersion(name prim.Wstring, version *prim.U32) FastlyStatus
 
@@ -1878,7 +1878,7 @@ func BackendGetSSLMinVersion(name string) (TLSVersion, error) {
 //	)
 //
 //go:wasm-module fastly_backend
-//export get_port
+//export get_ssl_max_version
 //go:noescape
 func fastlyBackendGetSSLMaxVersion(name prim.Wstring, version *prim.U32) FastlyStatus
 

--- a/internal/abi/fastly/hostcalls_noguest.go
+++ b/internal/abi/fastly/hostcalls_noguest.go
@@ -194,8 +194,8 @@ func BackendExists(name string) (bool, error) {
 	return false, fmt.Errorf("not implemented")
 }
 
-func BackendIsHealthy(name string) (bool, error) {
-	return false, fmt.Errorf("not implemented")
+func BackendIsHealthy(name string) (BackendHealth, error) {
+	return BackendHealthUnknown, fmt.Errorf("not implemented")
 }
 
 func BackendIsDynamic(name string) (bool, error) {
@@ -225,6 +225,7 @@ func BackendGetFirstByteTimeout(name string) (time.Duration, error) {
 func BackendGetBetweenBytesTimeout(name string) (time.Duration, error) {
 	return 0, fmt.Errorf("not implemented")
 }
+
 func BackendIsSSL(name string) (bool, error) {
 	return false, fmt.Errorf("not implemented")
 }

--- a/internal/abi/fastly/types.go
+++ b/internal/abi/fastly/types.go
@@ -749,6 +749,21 @@ type backendConfigOptions struct {
 
 // witx:
 //
+//	(typename $backend_health
+//	    (enum (@witx tag u32)
+//	        $unknown
+//	        $healthy
+//	        $unhealthy))
+type BackendHealth prim.U32
+
+const (
+	BackendHealthUnknown   BackendHealth = 0
+	BackendHealthHealthy   BackendHealth = 1
+	BackendHealthUnhealthy BackendHealth = 2
+)
+
+// witx:
+//
 //	(typename $tls_version
 //	    (enum (@witx tag u32)
 //	      $tls_1


### PR DESCRIPTION
Replace `backend.IsHealthy()` with `backend.Health()`, because it returns an
enum of 3 states (unknown, healthy, unhealthy) and not a bool.

When populating the backend, the runtime will return `FastlyStatusNone`
if a value isn't set.  This isn't an error, so we should ignore it.
Similarly, the Viceroy environment will return `FastlyStatusUnsupported`
for some unsupported fields and we should ignore them too.

The exported names for getting SSL min/max versions were copypasta'd and
returned the wrong values.

Fixes #65.
