### PR TITLE
return nicer ErrBackendNotFound when sending to unknown backend

### DIFF
--- a/fsthttp/request.go
+++ b/fsthttp/request.go
@@ -299,6 +299,15 @@ func (req *Request) Send(ctx context.Context, backend string) (*Response, error)
 
 	abiPending, abiReqBody, err := req.sendABIRequestAsync(backend)
 	if err != nil {
+		status, ok := fastly.IsFastlyError(err)
+		if !ok {
+			return nil, err
+		}
+
+		if status == fastly.FastlyStatusInval {
+			return nil, ErrBackendNotFound
+		}
+
 		return nil, err
 	}
 

--- a/internal/abi/fastly/types.go
+++ b/internal/abi/fastly/types.go
@@ -147,10 +147,21 @@ func (e FastlyError) getStatus() FastlyStatus {
 
 // IsFastlyError detects and unwraps a FastlyError to its component parts.
 func IsFastlyError(err error) (FastlyStatus, bool) {
-	if e, ok := err.(interface{ getStatus() FastlyStatus }); ok {
-		return e.getStatus(), true
+	for {
+		switch e := err.(type) {
+		case interface{ getStatus() FastlyStatus }:
+			return e.getStatus(), true
+
+		case interface{ Unwrap() error }:
+			err = e.Unwrap()
+			if err == nil {
+				return 0, false
+			}
+
+		default:
+			return 0, false
+		}
 	}
-	return 0, false
 }
 
 // HTTPVersion describes an HTTP protocol version.


### PR DESCRIPTION
We created this error for the dynamic backend work, but it applies to
Send() as well.

Because Send wraps the underlying FastlyStatus error, we need to support
unwrapping in IsFastlyError.
