### PR TITLE
_examples: add fastly.toml for each example, plus a README.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_examples/*/bin
+_examples/*/pkg

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then, you can install `compute-sdk-go` in your project by running:
 
 Examples can be found in the [`examples`](./_examples) directory.
 
-The Fastly Developer Hub has a collection of [common use cases in VCL ported to TinyGo](https://developer.fastly.com/learning/compute/migrate/). Which also acts as a great set of introductory examples of using TinyGo on Compute@Edge.
+The Fastly Developer Hub has a collection of [common use cases in VCL ported to TinyGo](https://developer.fastly.com/learning/compute/migrate/) which also acts as a great set of introductory examples of using TinyGo on Compute@Edge.
 
 ## API Reference
 

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -1,0 +1,116 @@
+# Go SDK Examples
+
+This directory contains examples of using the Go SDK.
+You can run them locally in Viceroy by running `fastly compute serve` from the individual example directory.
+
+#### [`add-or-remove-cookies`](./add-or-remove-cookies)
+
+This example shows how to read cookies from requests and how to add or remove cookies from responses.
+
+#### [`corecache`](./corecache)
+
+This example demonstrates the [Core Cache API](https://pkg.go.dev/github.com/fastly/compute-sdk-go/cache/core).
+
+Resources are specified by the URL path.  A `GET` will retrieve a value from the cache, a `POST` will insert the value into the cache, and a `DELETE` will purge the value from the cache.
+
+Note that this example isn't currently supported by Viceroy and has to be deployed to a Fastly service, which you can do with `fastly compute build` and `fastly compute deploy`.
+If you haven't previously deployed it, the CLI will walk you through the steps of creating a new service for it.
+
+#### [`geodata`](./geodata)
+
+A simple example demonstrating what's available from the [geographic data API](https://pkg.go.dev/github.com/fastly/compute-sdk-go/geo) for IP addresses.
+
+Note that Viceroy serves canned data for this API, but it can be customized in the `fastly.toml` file.
+See the [documentation](https://developer.fastly.com/reference/compute/fastly-toml/#geolocation) for details.
+
+#### [`hello-world`](./hello-world)
+
+The canonical example.  It demonstrates the basic structure of a Fastly Compute@Edge program in Go.
+
+#### [`http-adapter`](./http-adapter)
+
+The Go SDK provides a set of APIs in its [`fsthttp`](https://pkg.go.dev/github.com/fastly/compute-sdk-go/fsthttp) package which should be familiar to any Go programmer who has used the standard library's [`net/http`](https://pkg.go.dev/net/http) package.
+Although similar, the implementations are different and the types are not interchangeable.
+
+[An adapter](https://pkg.go.dev/github.com/fastly/compute-sdk-go/fsthttp#Adapt) is provided to allow existing `net/http` handlers to be used with the Fastly Compute@Edge API.
+This example demonstrates how to use it with [`http.ServeMux`](https://pkg.go.dev/net/http#ServeMux) from the standard library but it can be used with any other [`http.Handler`](https://pkg.go.dev/net/http#Handler), including ones from popular third-party libraries like [gorilla/mux](https://github.com/gorilla/mux) and [chi](https://github.com/go-chi/chi).
+
+#### [`kvstore`](./kvstore)
+
+An example demonstrating reading from the [Fastly KV Store API](https://pkg.go.dev/github.com/fastly/compute-sdk-go/kvstore).
+
+The KV store is populated locally by adding values to the `fastly.toml` file.
+See the [documentation](https://developer.fastly.com/reference/compute/fastly-toml/#kv-and-secret-stores) for details.
+
+#### [`limits`](./limits)
+
+This example demonstrates how to adjust certain [request limits](https://pkg.go.dev/github.com/fastly/compute-sdk-go/fsthttp#Limits) before handling requests.  This example increases the maximum URL length from the default 8k to 16k.
+
+#### [`logging-and-env`](./logging-and-env)
+
+This example demonstrates how logging works, both by printing to stdout and stderr and by sending to dedicated logging endpoints using the [`rtlog`](https://pkg.go.dev/github.com/fastly/compute-sdk-go/rtlog) package.
+It also prints out several environment variables that are set by default in the Compute@Edge environment.
+Note, however, that most of these environment variables are unset when running locally.
+
+#### [`middlewares`](./middlewares)
+
+A demonstration of how to build middleware on top of `fsthttp.Handler` just as you would for `net/http.Handler`.
+
+#### [`multiple-goroutines`](./multiple-goroutines)
+
+This example shows how your handlers can run multiple concurrently-running goroutines.
+
+#### [`parallel-requests`](./parallel-requests)
+
+Building on the previous example, this one demonstrates how to make multiple origin requests in parallel.
+Each request executes in its own goroutine.
+The contents of the responses are discarded, but the overall request should finish in about as long as the longest individual origin request took.
+
+#### [`print-request`](./print-request)
+
+Returns a response containing information about the incoming request.
+
+#### [`proxy-request`](./proxy-request)
+
+This example demonstrates how to act as a simple proxy, forwarding the incoming request to an origin server and returning the response to the client.
+
+#### [`proxy-request-framing`](./proxy-request-framing)
+
+A variation on the previous example, this one demonstrates how you can manually override the framing modes of requests and responses.
+This gives you control over `Content-Length` and `Transfer-Encoding` headers, which are normally handled automatically by the runtime.
+
+#### [`secret-store`](./secret-store)
+
+This example demonstrates the [Fastly Secret Store API](https://pkg.go.dev/github.com/fastly/compute-sdk-go/secretstore).
+A secret store is opened, a secret is looked up, and the value is decrypted and returned to the client.
+
+The secret store is populated locally by adding values to the `fastly.toml` file.
+Note that values in the `fastly.toml` file are not encrypted.
+See the [documentation](https://developer.fastly.com/reference/compute/fastly-toml/#kv-and-secret-stores) for details.
+
+#### [`set-cookie`](./set-cookie)
+
+A simple example that sets a cookie on the response.
+
+#### [`set-google-analytics`](./set-google-analytics)
+
+Due to [Intelligent Tracking Prevention 2.1](https://webkit.org/blog/8613/intelligent-tracking-prevention-2-1/) restrictions, cookies set from JavaScript are capped to 7 days of storage.
+This example demonstrates how to use Compute@Edge to set a first-party server-side cookie for Google Analytics that can last longer.
+
+#### [`simplecache`](./simplecache)
+
+This example demonstrates the [Simple Cache API](https://pkg.go.dev/github.com/fastly/compute-sdk-go/cache/simple).
+
+Resources are specified by the URL path.  A `GET` will retrieve a value from the cache, a `POST` will insert the value into the cache, and a `DELETE` will purge the value from the cache.
+
+Note that this example isn't currently supported by Viceroy and has to be deployed to a Fastly service, which you can do with `fastly compute build` and `fastly compute deploy`.
+If you haven't previously deployed it, the CLI will walk you through the steps of creating a new service for it.
+
+#### [`stream-response`](./stream-response)
+
+This example demonstrates a server that streams a response to the client by writing to the `http.ResponseWriter` in chunks, sleeping between each chunk.
+
+#### [`with-timeout`](./with-timeout)
+
+This example demonstrates how to use [`context.WithTimeout`](https://pkg.go.dev/context#WithTimeout) to set a timeout for origin requests.
+It is expected that this example prints "context deadline exceeded" to the logs.

--- a/_examples/add-or-remove-cookies/fastly.toml
+++ b/_examples/add-or-remove-cookies/fastly.toml
@@ -1,0 +1,11 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "add-or-remove-cookies"
+
+[local_server]
+backends.backend.url = "https://httpbin.org"

--- a/_examples/add-or-remove-cookies/fastly.toml
+++ b/_examples/add-or-remove-cookies/fastly.toml
@@ -8,4 +8,4 @@ manifest_version = 2
 name = "add-or-remove-cookies"
 
 [local_server]
-backends.backend.url = "https://httpbin.org"
+backends.backend.url = "https://http-me.glitch.me"

--- a/_examples/corecache/fastly.toml
+++ b/_examples/corecache/fastly.toml
@@ -1,0 +1,13 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "corecache"
+
+# Note that this example doesn't currently work with Viceroy (`fastly
+# compute serve`) so you'll need to deploy it to Compute@Edge in order
+# to test it.  You can do that with `fastly compute build` and `fastly
+# compute deploy`.

--- a/_examples/geodata/fastly.toml
+++ b/_examples/geodata/fastly.toml
@@ -1,0 +1,11 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "geodata"
+
+# You can customize the geodata that is returned.  See the developer
+# documentation linked above for more info.

--- a/_examples/hello-world/fastly.toml
+++ b/_examples/hello-world/fastly.toml
@@ -1,0 +1,8 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "hello-world"

--- a/_examples/kvstore/fastly.toml
+++ b/_examples/kvstore/fastly.toml
@@ -1,0 +1,11 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "kvstore"
+
+[local_server]
+kv_stores.example_kvstore = [{key = "foo", data = "Hello from KV Store!\n"}]

--- a/_examples/limits/fastly.toml
+++ b/_examples/limits/fastly.toml
@@ -1,0 +1,8 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "limits"

--- a/_examples/limits/main.go
+++ b/_examples/limits/main.go
@@ -14,6 +14,11 @@ func main() {
 	fsthttp.RequestLimits.SetMaxURLLen(16 * 1024)
 
 	fsthttp.ServeFunc(func(ctx context.Context, w fsthttp.ResponseWriter, r *fsthttp.Request) {
-		fmt.Fprintf(w, "The length of the URL is %d\n", len(r.URL.String()))
+		fmt.Fprintf(
+			w,
+			"The length of the URL is %d and the maximum is %d\n",
+			len(r.URL.String()),
+			fsthttp.RequestLimits.MaxURLLen(),
+		)
 	})
 }

--- a/_examples/logging-and-env/fastly.toml
+++ b/_examples/logging-and-env/fastly.toml
@@ -1,0 +1,8 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "logging-and-env"

--- a/_examples/middlewares/fastly.toml
+++ b/_examples/middlewares/fastly.toml
@@ -1,0 +1,8 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "middlewares"

--- a/_examples/multiple-goroutines/fastly.toml
+++ b/_examples/multiple-goroutines/fastly.toml
@@ -1,0 +1,8 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "multiple-goroutines"

--- a/_examples/parallel-requests/fastly.toml
+++ b/_examples/parallel-requests/fastly.toml
@@ -1,0 +1,11 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "parallel-requests"
+
+[local_server]
+backends.httpbin.url = "https://httpbin.org"

--- a/_examples/parallel-requests/fastly.toml
+++ b/_examples/parallel-requests/fastly.toml
@@ -8,4 +8,4 @@ manifest_version = 2
 name = "parallel-requests"
 
 [local_server]
-backends.httpbin.url = "https://httpbin.org"
+backends.httpme.url = "https://http-me.glitch.me"

--- a/_examples/parallel-requests/main.go
+++ b/_examples/parallel-requests/main.go
@@ -23,9 +23,9 @@ func main() {
 		// Send several requests in parallel.
 		var wg sync.WaitGroup
 		for _, url := range []string{
-			"https://httpbin.org/drip?delay=4&duration=1", // delay 4s + stream response body 1s = 5s
-			"https://httpbin.org/drip?delay=2&duration=2", // delay 2s + stream response body 2s = 4s
-			"https://httpbin.org/delay/3",                 // delay 3s + stream response body 0s = 3s
+			"https://http-me.glitch.me/drip=2?wait=3000", // delay 3s + stream body 2s = 5s
+			"https://http-me.glitch.me/drip=2?wait=2000", // delay 2s + stream body 2s = 4s
+			"https://http-me.glitch.me/wait=3000",        // delay 3s + stream body 0s = 3s
 		} {
 			wg.Add(1)
 			go func(url string) {
@@ -42,7 +42,7 @@ func main() {
 				// Sending HTTP requests in separate goroutines is both
 				// concurrent and parallel. For example, 3 requests that each
 				// take 3s to return a response will take about 3s in total.
-				resp, err := req.Send(ctx, "httpbin")
+				resp, err := req.Send(ctx, "httpme")
 				if err != nil {
 					log.Printf("%s: send request: %v", url, err)
 					return

--- a/_examples/print-request/fastly.toml
+++ b/_examples/print-request/fastly.toml
@@ -1,0 +1,8 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "print-request"

--- a/_examples/proxy-request-framing/fastly.toml
+++ b/_examples/proxy-request-framing/fastly.toml
@@ -1,0 +1,11 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "proxy-request-framing"
+
+[local_server]
+backends.httpbin.url = "https://httpbin.org"

--- a/_examples/proxy-request-framing/fastly.toml
+++ b/_examples/proxy-request-framing/fastly.toml
@@ -8,4 +8,4 @@ manifest_version = 2
 name = "proxy-request-framing"
 
 [local_server]
-backends.httpbin.url = "https://httpbin.org"
+backends.httpme.url = "https://http-me.glitch.me"

--- a/_examples/proxy-request-framing/main.go
+++ b/_examples/proxy-request-framing/main.go
@@ -13,8 +13,8 @@ func main() {
 	fsthttp.ServeFunc(func(ctx context.Context, w fsthttp.ResponseWriter, r *fsthttp.Request) {
 		// Reset the URI and Host header, so the request is
 		// recognized and routed correctly at the origin.
-		r.URL.Scheme, r.URL.Host = "https", "httpbin.org"
-		r.Header.Set("host", "httpbin.org")
+		r.URL.Scheme, r.URL.Host = "https", "http-me.glitch.me"
+		r.Header.Set("host", "http-me.glitch.me")
 
 		// Determine the framing headers (Content-Length/Transfer-Encoding)
 		// based on the message body (default)
@@ -24,8 +24,8 @@ func main() {
 		r.CacheOptions.Pass = true
 
 		// This requires your service to be configured with a backend
-		// named "httpbin" and pointing to "https://httpbin.org".
-		resp, err := r.Send(ctx, "httpbin")
+		// named "httpme" and pointing to "https://http-me.glitch.me".
+		resp, err := r.Send(ctx, "httpme")
 		if err != nil {
 			fsthttp.Error(w, err.Error(), fsthttp.StatusBadGateway)
 			return

--- a/_examples/proxy-request/fastly.toml
+++ b/_examples/proxy-request/fastly.toml
@@ -1,0 +1,11 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "proxy-request"
+
+[local_server]
+backends.httpbin.url = "https://httpbin.org"

--- a/_examples/proxy-request/fastly.toml
+++ b/_examples/proxy-request/fastly.toml
@@ -8,4 +8,4 @@ manifest_version = 2
 name = "proxy-request"
 
 [local_server]
-backends.httpbin.url = "https://httpbin.org"
+backends.httpme.url = "https://http-me.glitch.me"

--- a/_examples/proxy-request/main.go
+++ b/_examples/proxy-request/main.go
@@ -13,15 +13,15 @@ func main() {
 	fsthttp.ServeFunc(func(ctx context.Context, w fsthttp.ResponseWriter, r *fsthttp.Request) {
 		// Reset the URI and Host header, so the request is
 		// recognized and routed correctly at the origin.
-		r.URL.Scheme, r.URL.Host = "https", "httpbin.org"
-		r.Header.Set("host", "httpbin.org")
+		r.URL.Scheme, r.URL.Host = "https", "http-me.glitch.me"
+		r.Header.Set("host", "http-me.glitch.me")
 
 		// Make sure the response isn't cached.
 		r.CacheOptions.Pass = true
 
 		// This requires your service to be configured with a backend
-		// named "httpbin" and pointing to "https://httpbin.org".
-		resp, err := r.Send(ctx, "httpbin")
+		// named "httpme" and pointing to "https://http-me.glitch.me".
+		resp, err := r.Send(ctx, "httpme")
 		if err != nil {
 			fsthttp.Error(w, err.Error(), fsthttp.StatusBadGateway)
 			return

--- a/_examples/secret-store/fastly.toml
+++ b/_examples/secret-store/fastly.toml
@@ -1,0 +1,11 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "secret-store"
+
+[local_server]
+secret_stores.example_secretstore = [{key = "my_secret", data = "Open sesame!"}]

--- a/_examples/set-cookie/fastly.toml
+++ b/_examples/set-cookie/fastly.toml
@@ -1,0 +1,8 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "set-cookie"

--- a/_examples/set-google-analytics/fastly.toml
+++ b/_examples/set-google-analytics/fastly.toml
@@ -8,4 +8,4 @@ manifest_version = 2
 name = "set-google-analytics"
 
 [local_server]
-backends.backend.url = "https://httpbin.org"
+backends.backend.url = "https://http-me.glitch.me"

--- a/_examples/set-google-analytics/fastly.toml
+++ b/_examples/set-google-analytics/fastly.toml
@@ -1,0 +1,11 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "set-google-analytics"
+
+[local_server]
+backends.backend.url = "https://httpbin.org"

--- a/_examples/simplecache/fastly.toml
+++ b/_examples/simplecache/fastly.toml
@@ -1,0 +1,13 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "simplecache"
+
+# Note that this example doesn't currently work with Viceroy (`fastly
+# compute serve`) so you'll need to deploy it to Compute@Edge in order
+# to test it.  You can do that with `fastly compute build` and `fastly
+# compute deploy`.

--- a/_examples/stream-response/fastly.toml
+++ b/_examples/stream-response/fastly.toml
@@ -1,0 +1,8 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "stream-response"

--- a/_examples/with-timeout/fastly.toml
+++ b/_examples/with-timeout/fastly.toml
@@ -1,0 +1,11 @@
+# This file describes a Fastly Compute@Edge package. To learn more visit:
+# https://developer.fastly.com/reference/fastly-toml/
+
+authors = ["oss@fastly.com"]
+description = ""
+language = "go"
+manifest_version = 2
+name = "with-timeout"
+
+[local_server]
+backends.httpbin.url = "https://httpbin.org"

--- a/_examples/with-timeout/fastly.toml
+++ b/_examples/with-timeout/fastly.toml
@@ -8,4 +8,4 @@ manifest_version = 2
 name = "with-timeout"
 
 [local_server]
-backends.httpbin.url = "https://httpbin.org"
+backends.httpme.url = "https://http-me.glitch.me"

--- a/_examples/with-timeout/main.go
+++ b/_examples/with-timeout/main.go
@@ -19,7 +19,7 @@ func main() {
 		defer cancel()
 
 		// Create the request, and set pass to true, to avoid caching.
-		req, err := fsthttp.NewRequest(fsthttp.MethodGet, "https://httpbin.org/delay/3", nil)
+		req, err := fsthttp.NewRequest(fsthttp.MethodGet, "https://http-me.glitch.me/wait=3000", nil)
 		if err != nil {
 			log.Printf("create request: %v", err)
 			return
@@ -28,8 +28,8 @@ func main() {
 
 		// This request takes 3 seconds to complete but should error after 1
 		// second. It also requires your service to be configured with a backend
-		// named "httpbin" and pointing to "https://httpbin.org".
-		_, err = req.Send(ctx, "httpbin")
+		// named "httpme" and pointing to "https://http-me.glitch.me".
+		_, err = req.Send(ctx, "httpme")
 		if err != nil {
 			log.Printf("send request errored after %s: %v", time.Since(begin), err)
 			return


### PR DESCRIPTION
This mades it so you can run `fastly compute serve` in each example
directory to test them out locally.

Fixes #67