### PR TITLE
Add Append method to ResponseWriter

### DIFF
--- a/fsthttp/response.go
+++ b/fsthttp/response.go
@@ -112,8 +112,8 @@ type ResponseWriter interface {
 	// To have an effect on the response, this must be called before any call to Write() or WriteHeader().
 	SetManualFramingMode(bool)
 
-	// Append a body onto the end of this response.
-	// This operation is performed in amortized constant time, and so should always be preferred to reading an entire body and then writing the same contents to another body.
+	// Append a body onto the end of this response. Will fail if passed anything other than a Response's Body field.
+	// This operation is performed in amortized constant time, and so should always be preferred to directly copying a body with io.Copy.
 	Append(other io.ReadCloser) error
 }
 

--- a/fsthttp/response.go
+++ b/fsthttp/response.go
@@ -111,6 +111,10 @@ type ResponseWriter interface {
 	//
 	// To have an effect on the response, this must be called before any call to Write() or WriteHeader().
 	SetManualFramingMode(bool)
+
+	// Append a body onto the end of this response.
+	// This operation is performed in amortized constant time, and so should always be preferred to reading an entire body and then writing the same contents to another body.
+	Append(other io.ReadCloser) error
 }
 
 type responseWriter struct {
@@ -166,4 +170,13 @@ func (resp *responseWriter) Close() error {
 
 func (resp *responseWriter) SetManualFramingMode(mode bool) {
 	resp.ManualFramingMode = mode
+}
+
+func (resp *responseWriter) Append(other io.ReadCloser) error {
+	otherAbiBody, ok := other.(*fastly.HTTPBody)
+	if !ok {
+		return fmt.Errorf("non-Response Body passed to ResponseWriter.Append")
+	}
+	resp.abiBody.Append(otherAbiBody)
+	return nil
 }

--- a/fsttest/recorder.go
+++ b/fsttest/recorder.go
@@ -2,6 +2,7 @@ package fsttest
 
 import (
 	"bytes"
+	"io"
 
 	"github.com/fastly/compute-sdk-go/fsthttp"
 )
@@ -48,3 +49,9 @@ func (r *ResponseRecorder) Close() error {
 // SetManualFramingMode is a no-op on ResponseRecorder.  It exists to
 // satisfy the fsthttp.ResponseWriter interface.
 func (r *ResponseRecorder) SetManualFramingMode(v bool) {}
+
+// Append is a no-op on ResponseRecorder.  It exists to
+// satisfy the fsthttp.ResponseWriter interface.
+func (r *ResponseRecorder) Append(other io.ReadCloser) error {
+	return nil
+}

--- a/fsttest/recorder.go
+++ b/fsttest/recorder.go
@@ -2,9 +2,11 @@ package fsttest
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 
 	"github.com/fastly/compute-sdk-go/fsthttp"
+	"github.com/fastly/compute-sdk-go/internal/abi/fastly"
 )
 
 // ResponseRecorder is an implementation of fsthttp.ResponseWriter that
@@ -50,8 +52,17 @@ func (r *ResponseRecorder) Close() error {
 // satisfy the fsthttp.ResponseWriter interface.
 func (r *ResponseRecorder) SetManualFramingMode(v bool) {}
 
-// Append is a no-op on ResponseRecorder.  It exists to
-// satisfy the fsthttp.ResponseWriter interface.
+// Append records the response body.  The data is written to the Body
+// field of the ResponseRecorder.
 func (r *ResponseRecorder) Append(other io.ReadCloser) error {
-	return nil
+	// do the same type check as the real implementation
+	_, ok := other.(*fastly.HTTPBody)
+	if !ok {
+		return fmt.Errorf("non-Response Body passed to ResponseWriter.Append")
+	}
+	// the real implementation makes a host call to do the body append
+	// without a real body handle to write to, we'll just use io.Copy to the same
+	// effect
+	_, err := io.Copy(r, other)
+	return err
 }

--- a/integration_tests/request_upstream/main_test.go
+++ b/integration_tests/request_upstream/main_test.go
@@ -14,6 +14,11 @@ import (
 )
 
 func TestRequestUpstream(t *testing.T) {
+	t.Run("useAppend=false", func(t *testing.T) { requestUpstream(false, t) })
+	t.Run("useAppend=true", func(t *testing.T) { requestUpstream(true, t) })
+}
+
+func requestUpstream(useAppend bool, t *testing.T) {
 	handler := func(ctx context.Context, w fsthttp.ResponseWriter, _ *fsthttp.Request) {
 		// Create our upstream request
 		req, err := fsthttp.NewRequest("GET", "https://compute-sdk-test-backend.edgecompute.app/request_upstream", nil)
@@ -39,7 +44,11 @@ func TestRequestUpstream(t *testing.T) {
 
 		w.Header().Reset(resp.Header.Clone())
 		w.WriteHeader(resp.StatusCode)
-		io.Copy(w, resp.Body)
+		if useAppend {
+			w.Append(resp.Body)
+		} else {
+			io.Copy(w, resp.Body)
+		}
 	}
 
 	r, err := fsthttp.NewRequest("GET", "/", nil)


### PR DESCRIPTION
This mirrors the Response::append_body method in the Rust SDK: https://docs.rs/fastly/0.9.5/fastly/http/struct.Response.html#method.append_body