### PR TITLE
Switch to v2 send hostcalls with better error reporting

### DIFF
--- a/internal/abi/fastly/hostcalls_guest.go
+++ b/internal/abi/fastly/hostcalls_guest.go
@@ -1231,7 +1231,7 @@ func (r *HTTPRequest) Send(requestBody *HTTPBody, backend string) (response *HTT
 		prim.ToPointer(&errDetail),
 		prim.ToPointer(&resp.h),
 		prim.ToPointer(&respBody.h),
-	).toErrorDetailed(errDetail); err != nil {
+	).toSendError(errDetail); err != nil {
 		return nil, nil, err
 	}
 
@@ -1364,7 +1364,7 @@ func (r *PendingRequest) Poll() (done bool, response *HTTPResponse, responseBody
 		prim.ToPointer(&isDone),
 		prim.ToPointer(&resp.h),
 		prim.ToPointer(&respBody.h),
-	).toErrorDetailed(errDetail); err != nil {
+	).toSendError(errDetail); err != nil {
 		return false, nil, nil, err
 	}
 
@@ -1410,7 +1410,7 @@ func (r *PendingRequest) Wait() (response *HTTPResponse, responseBody *HTTPBody,
 		prim.ToPointer(&errDetail),
 		prim.ToPointer(&resp.h),
 		prim.ToPointer(&respBody.h),
-	).toErrorDetailed(errDetail); err != nil {
+	).toSendError(errDetail); err != nil {
 		return nil, nil, err
 	}
 


### PR DESCRIPTION
This switches the Go SDK to use new versions of hostcalls added to improve error reporting when sending requests to backends.

A new `sendErrorDetail` type is created, which implements `error` and translates the various tag values to a human-readable string.

`FastlyError` now holds an `error` field named `Detail` in addition to a `FastlyStatus`.  When `Detail` is set, the `FastlyError` will return the `Detail` error string instead of the `FastlyStatus` string.

`FastlyStatus` gains a new `toSendError` method which takes a `sendErrorDetail` and constructs a `FastlyError` with the detail appropriately set.

As a result the generic "Error" message when encountering backend errors should now be replaced with a more detailed message.

Fixes #87.
