### PR TITLE
Improve error handling

### DIFF
--- a/cache/core/core.go
+++ b/cache/core/core.go
@@ -74,6 +74,9 @@ var (
 	// ErrUnsupported is returned when a cache operation is not
 	// supported.
 	ErrUnsupported = errors.New("cache: operation not supported")
+
+	// ErrUnexpected is returned when an unexpected error occurs.
+	ErrUnexpected = errors.New("cache: unexpected error")
 )
 
 // Found represents a cached object found by a cache lookup.
@@ -750,7 +753,7 @@ func mapFastlyError(err error) error {
 	case fastly.FastlyStatusUnsupported:
 		return ErrUnsupported
 	default:
-		return err
+		return fmt.Errorf("%w (%s)", ErrUnexpected, status)
 	}
 }
 

--- a/configstore/configstore.go
+++ b/configstore/configstore.go
@@ -4,6 +4,7 @@ package configstore
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/fastly/compute-sdk-go/internal/abi/fastly"
 )
@@ -26,6 +27,9 @@ var (
 
 	// ErrKeyNotFound indicates a key isn't in a config store.
 	ErrKeyNotFound = errors.New("key not found")
+
+	// ErrUnexpected indicates an unexpected error occurred.
+	ErrUnexpected = errors.New("unexpected error")
 )
 
 // Store is a read-only representation of a config store.
@@ -48,6 +52,8 @@ func Open(name string) (*Store, error) {
 			return nil, ErrStoreNameTooLong
 		case ok && status == fastly.FastlyStatusInval:
 			return nil, ErrStoreNameInvalid
+		case ok:
+			return nil, fmt.Errorf("%w (%s)", ErrUnexpected, status)
 		default:
 			return nil, err
 		}
@@ -69,6 +75,8 @@ func (s *Store) Get(key string) (string, error) {
 			return "", ErrStoreNotFound
 		case ok && status == fastly.FastlyStatusNone:
 			return "", ErrKeyNotFound
+		case ok:
+			return "", fmt.Errorf("%w (%s)", ErrUnexpected, status)
 		default:
 			return "", err
 		}

--- a/fsthttp/backend.go
+++ b/fsthttp/backend.go
@@ -2,6 +2,7 @@ package fsthttp
 
 import (
 	"errors"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -18,6 +19,9 @@ var (
 
 	// ErrBackendNotFound indicates the provided backend was not found.
 	ErrBackendNotFound = errors.New("backend not found")
+
+	// ErrUnexpected indicates an unexpected error occurred.
+	ErrUnexpected = errors.New("unexpected error")
 )
 
 type BackendHealth uint32
@@ -291,6 +295,8 @@ func RegisterDynamicBackend(name string, target string, options *BackendOptions)
 			return nil, ErrDynamicBackendDisallowed
 		case ok && status == fastly.FastlyStatusError:
 			return nil, ErrBackendNameInUse
+		case ok:
+			return nil, fmt.Errorf("%w (%s)", ErrUnexpected, status)
 		default:
 			return nil, err
 		}

--- a/secretstore/secretstore.go
+++ b/secretstore/secretstore.go
@@ -11,6 +11,7 @@ package secretstore
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/fastly/compute-sdk-go/internal/abi/fastly"
 )
@@ -58,7 +59,7 @@ func Open(name string) (*Store, error) {
 		case ok && status == fastly.FastlyStatusInval:
 			return nil, ErrInvalidSecretStoreName
 		case ok:
-			return nil, ErrUnexpected
+			return nil, fmt.Errorf("%w (%s)", ErrUnexpected, status)
 		default:
 			return nil, err
 		}
@@ -79,7 +80,7 @@ func (st *Store) Get(name string) (*Secret, error) {
 		case ok && status == fastly.FastlyStatusInval:
 			return nil, ErrInvalidSecretName
 		case ok:
-			return nil, ErrUnexpected
+			return nil, fmt.Errorf("%w (%s)", ErrUnexpected, status)
 		default:
 			return nil, err
 		}
@@ -92,9 +93,9 @@ func (st *Store) Get(name string) (*Secret, error) {
 func (s *Secret) Plaintext() ([]byte, error) {
 	plaintext, err := s.s.Plaintext()
 	if err != nil {
-		_, ok := fastly.IsFastlyError(err)
+		status, ok := fastly.IsFastlyError(err)
 		if ok {
-			return nil, ErrUnexpected
+			return nil, fmt.Errorf("%w (%s)", ErrUnexpected, status)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
This PR improves the error handling in a handful of places.

It adds contextual errors to the `kvstore` package, so we're not returning user unfriendly raw `FastlyStatus` error codes.

It also adds an unexpected error sentinel to most packages if they don't already have them, and adds the `FastlyStatus` code to them for easier debugging.

Fixes #16, #23, and #83.
