### PR TITLE
.github: update CI versions

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -4,8 +4,13 @@ jobs:
   build-examples-tinygo:
     strategy:
       matrix:
-        go-version: ['~1.20.0', '~1.19.0']
-        tinygo-version: ['0.28.1']
+        include:
+          # Newest supported configuration
+          - go-version: '~1.21.0'
+            tinygo-version: '0.30.0'
+          # Oldest supported configuration
+          - go-version: '~1.19.0'
+            tinygo-version: '0.28.1'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout fastly/compute-sdk-go

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,9 +1,18 @@
 name: Integration Tests
 on: [push]
 env:
-  VICEROY_VERSION: 0.8.1
+  VICEROY_VERSION: 0.9.2
 jobs:
   integration-tests-tinygo:
+    strategy:
+      matrix:
+        include:
+          # Newest supported configuration
+          - go-version: '~1.21.0'
+            tinygo-version: '0.30.0'
+          # Oldest supported configuration
+          - go-version: '~1.19.0'
+            tinygo-version: '0.28.1'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout fastly/compute-sdk-go
@@ -11,11 +20,11 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: '~1.20.0'
+          go-version: ${{ matrix.go-version }}
       - name: Install TinyGo
         uses: ./.github/actions/install-tinygo
         with:
-          tinygo-version: '0.28.1'
+          tinygo-version: ${{ matrix.tinygo-version }}
       - name: Setup Fastly CLI
         uses: fastly/compute-actions/setup@v5
       - name: Install Viceroy ${{ env.VICEROY_VERSION }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+- Improve error handling and documentation in `kvstore` package
+- Use new hostcalls for better error messages when sending requests to a backend
+- Add better unexpected error handling (`cache/core`, `configstore`, `secretstore`)
+
 ## 1.0.0 (2023-09-13)
 
 - Unchanged from 0.2.0


### PR DESCRIPTION
Update Viceroy to 0.9.2.

Test builds with newest and oldest supported combinations of Go and
TinyGo.  Currently this is 1.19.x with 0.28.1 and 1.21.x with 0.30.0.
