### PR TITLE
cw/geo errors

### DIFF
--- a/geo/geodata.go
+++ b/geo/geodata.go
@@ -12,9 +12,6 @@ import (
 )
 
 var (
-	// ErrNotFound indicates there was no geo data returned.
-	ErrNotFound = errors.New("geo: no data found")
-
 	// ErrInvalidIP indicates the input IP was invalid.
 	ErrInvalidIP = errors.New("geo: invalid IP")
 
@@ -51,7 +48,12 @@ func Lookup(ip net.IP) (*Geo, error) {
 		status, ok := fastly.IsFastlyError(err)
 		switch {
 		case ok && status == fastly.FastlyStatusNone:
-			return nil, ErrNotFound
+			// Viceroy <= 0.9.3 returns fastly.FastlyStatusNone when no geolocation
+			// data is available. The Compute production environment instead returns
+			// empty data, which is handled by falling through to code below this switch.
+
+			// TODO: potential breaking change if bumping major version
+			// return nil, ErrNotFound
 		case ok && status == fastly.FastlyStatusInval:
 			return nil, ErrInvalidIP
 		case ok:

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/fastly/compute-sdk-go
 
-go 1.18
+go 1.20

--- a/integration_tests/geolocation/main_test.go
+++ b/integration_tests/geolocation/main_test.go
@@ -12,35 +12,50 @@ import (
 )
 
 func assert[T comparable](t *testing.T, field string, got, want T) {
+	t.Helper()
 	if got != want {
 		t.Errorf("%s: got %v, want %v", field, got, want)
 	}
 }
 
 func TestGeolocation(t *testing.T) {
-	g, err := geo.Lookup(net.ParseIP("127.0.0.1"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	t.Run("found", func(t *testing.T) {
+		g, err := geo.Lookup(net.ParseIP("127.0.0.1"))
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	assert(t, "AsName", g.AsName, "Fastly Test")
-	assert(t, "AsNumber", g.AsNumber, 12345)
-	assert(t, "AreaCode", g.AreaCode, 123)
-	assert(t, "City", g.City, "Test City")
-	assert(t, "ConnSpeed", g.ConnSpeed, "broadband")
-	assert(t, "ConnType", g.ConnType, "wired")
-	assert(t, "ContinentCode", g.ContinentCode, "NA")
-	assert(t, "CountryCode", g.CountryCode, "CA")
-	assert(t, "CountryCode3", g.CountryCode3, "CAN")
-	assert(t, "CountryName", g.CountryName, "Canada")
-	assert(t, "Latitude", g.Latitude, 12.345)
-	assert(t, "Longitude", g.Longitude, 54.321)
-	assert(t, "MetroCode", g.MetroCode, 1)
-	assert(t, "PostalCode", g.PostalCode, "12345")
-	assert(t, "ProxyDescription", g.ProxyDescription, "?")
-	assert(t, "ProxyType", g.ProxyType, "?")
-	assert(t, "Region", g.Region, "BC")
-	assert(t, "UTCOffset", g.UTCOffset, -700)
+		assert(t, "AsName", g.AsName, "Fastly Test")
+		assert(t, "AsNumber", g.AsNumber, 12345)
+		assert(t, "AreaCode", g.AreaCode, 123)
+		assert(t, "City", g.City, "Test City")
+		assert(t, "ConnSpeed", g.ConnSpeed, "broadband")
+		assert(t, "ConnType", g.ConnType, "wired")
+		assert(t, "ContinentCode", g.ContinentCode, "NA")
+		assert(t, "CountryCode", g.CountryCode, "CA")
+		assert(t, "CountryCode3", g.CountryCode3, "CAN")
+		assert(t, "CountryName", g.CountryName, "Canada")
+		assert(t, "Latitude", g.Latitude, 12.345)
+		assert(t, "Longitude", g.Longitude, 54.321)
+		assert(t, "MetroCode", g.MetroCode, 1)
+		assert(t, "PostalCode", g.PostalCode, "12345")
+		assert(t, "ProxyDescription", g.ProxyDescription, "?")
+		assert(t, "ProxyType", g.ProxyType, "?")
+		assert(t, "Region", g.Region, "BC")
+		assert(t, "UTCOffset", g.UTCOffset, -700)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		g, err := geo.Lookup(net.ParseIP("127.0.0.9"))
+		assert(t, "Geo{}", g, nil)
+		assert(t, "err", err, geo.ErrNotFound)
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		g, err := geo.Lookup(net.IP("127.0.0.9")) // Note: don't do this, net.IP is actually []byte()
+		assert(t, "Geo{}", g, nil)
+		assert(t, "err", err, geo.ErrInvalidIP)
+	})
 }
 
 func BenchmarkGeo(b *testing.B) {

--- a/integration_tests/geolocation/main_test.go
+++ b/integration_tests/geolocation/main_test.go
@@ -47,8 +47,8 @@ func TestGeolocation(t *testing.T) {
 
 	t.Run("not found", func(t *testing.T) {
 		g, err := geo.Lookup(net.ParseIP("127.0.0.9"))
-		assert(t, "Geo{}", g, nil)
-		assert(t, "err", err, geo.ErrNotFound)
+		assert(t, "Geo{}", *g, geo.Geo{})
+		assert(t, "err", err, nil)
 	})
 
 	t.Run("invalid", func(t *testing.T) {


### PR DESCRIPTION
geo: Unpacks internal errors using the IsFastlyError helper.

- go.mod: use go 1.20 for comparable constraint
- geo: use IsFastlyError helper to improve error messages
