### PR TITLE
don't defer closing the response writer

### DIFF
--- a/fsthttp/handle.go
+++ b/fsthttp/handle.go
@@ -35,8 +35,8 @@ func Serve(h Handler) {
 		}
 	})
 
-	defer clientResponseWriter.Close()
 	h.ServeHTTP(ctx, clientResponseWriter, clientRequest)
+	clientResponseWriter.Close()
 }
 
 // ServeFunc is sugar for Serve(HandlerFunc(f)).


### PR DESCRIPTION
Closing the response writer signifies to the Compute runtime that the
response has been successfully completed, so we shouldn't defer it in
case the handler panics.

In TinyGo, defers aren't run after panic so this wasn't executed.  In
Go, defers are run.  The result of this was that if a handler panicked
before sending a response, it would send an empty 200 OK response in Go
but a 500 Internal Server Error in TinyGo.

Fixes #98.
