### PR TITLE
Implement KVStore delete method

### DIFF
--- a/integration_tests/kvstore/main_test.go
+++ b/integration_tests/kvstore/main_test.go
@@ -39,4 +39,20 @@ func TestKVStore(t *testing.T) {
 	if got, want := animal.String(), "cat"; got != want {
 		t.Errorf("Insert: got %q, want %q", got, want)
 	}
+
+	if err = store.Delete("animal"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = store.Lookup("animal")
+	if err == nil {
+		t.Error("expected Lookup failure")
+	}
+
+	/*
+		// TODO(athomason) address inconsistent behavior in viceroy and production
+		if err = store.Delete("nonexistent"); err != nil {
+			t.Fatal(err)
+		}
+	*/
 }

--- a/internal/abi/fastly/hostcalls_noguest.go
+++ b/internal/abi/fastly/hostcalls_noguest.go
@@ -319,6 +319,10 @@ func (o *KVStore) Insert(key string, value io.Reader) error {
 	return fmt.Errorf("not implemented")
 }
 
+func (o *KVStore) Delete(key string) error {
+	return fmt.Errorf("not implemented")
+}
+
 type (
 	SecretStore struct{}
 	Secret      struct{}

--- a/kvstore/kvstore.go
+++ b/kvstore/kvstore.go
@@ -129,3 +129,22 @@ func (s *Store) Insert(key string, value io.Reader) error {
 	}
 	return nil
 }
+
+// Delete removes a key from the associated KV store.
+func (s *Store) Delete(key string) error {
+	err := s.kvstore.Delete(key)
+	if err != nil {
+		status, ok := fastly.IsFastlyError(err)
+		switch {
+		case ok && status == fastly.FastlyStatusNone:
+			return ErrKeyNotFound
+		case ok && status == fastly.FastlyStatusInval:
+			return ErrInvalidKey
+		case ok:
+			return fmt.Errorf("%w (%s)", ErrUnexpected, status)
+		default:
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
Note that the synchronous `delete` hostcall doesn't exist unlike `insert` and `lookup`, so this uses `delete_async` and `pending_delete_wait` like the Rust and JS SDKs do.