### PR TITLE
Switch request reflector backend

### DIFF
--- a/integration_tests/request_upstream/fastly.toml
+++ b/integration_tests/request_upstream/fastly.toml
@@ -22,4 +22,4 @@ service_id = ""
       url = "https://example.org/"
 
     [local_server.backends.httpme]
-      url = "https://http-me.glitch.me"
+      url = "https://http.edgecompute.app/anything/"

--- a/integration_tests/request_upstream/main_test.go
+++ b/integration_tests/request_upstream/main_test.go
@@ -87,7 +87,7 @@ const bodySize = 64 * 1024
 func TestRequestUpstreamBody(t *testing.T) {
 	body := make([]byte, bodySize)
 	for i := range body {
-		body[i] = byte(i)
+		body[i] = 'A'
 	}
 
 	b, err := fastly.NewHTTPBody()
@@ -124,7 +124,7 @@ func TestRequestUpstreamBody(t *testing.T) {
 }
 
 func requestUpstreamBody(t *testing.T, body io.Reader, size int, chunked bool) {
-	req, err := fsthttp.NewRequest("POST", "https://http-me.glitch.me/?anything", body)
+	req, err := fsthttp.NewRequest("POST", "https://http.edgecompute.app/anything/", body)
 	if err != nil {
 		t.Fatalf("NewRequest: %v", err)
 	}


### PR DESCRIPTION
Requests to http-me.glitch.me occasionally fail with 500 errors, leading to test flakes [1]. @BrooksCunningham suggests using the nearly compatible http.edgecompute.app [2] instead, which seems to be more reliable and substantially faster thanks to being hosted directly on Fastly Compute.

One required change is not sending invalid UTF-8 in the request body, which results in a 500 Internal Server Error.

1. https://github.com/fastly/compute-sdk-go/actions/runs/8839087224/job/24271648933
2. https://github.com/BrooksCunningham/http-me-rust