### PR TITLE
Add a `Has` method to Dictionary

### DIFF
--- a/configstore/configstore.go
+++ b/configstore/configstore.go
@@ -61,7 +61,8 @@ func Open(name string) (*Store, error) {
 	return &Store{d}, nil
 }
 
-// Get returns the item in the config store with the given key.
+// Has checks to see if the item exists in the config store, without allocating
+// any space to read it.
 func (s *Store) Has(key string) (bool, error) {
 	if s == nil {
 		return false, ErrKeyNotFound

--- a/configstore/configstore.go
+++ b/configstore/configstore.go
@@ -62,6 +62,30 @@ func Open(name string) (*Store, error) {
 }
 
 // Get returns the item in the config store with the given key.
+func (s *Store) Has(key string) (bool, error) {
+	if s == nil {
+		return false, ErrKeyNotFound
+	}
+
+	v, err := s.abiDict.Has(key)
+	if err != nil {
+		status, ok := fastly.IsFastlyError(err)
+		switch {
+		case ok && status == fastly.FastlyStatusBadf:
+			return false, ErrStoreNotFound
+		case ok && status == fastly.FastlyStatusNone:
+			return false, ErrKeyNotFound
+		case ok:
+			return false, fmt.Errorf("%w (%s)", ErrUnexpected, status)
+		default:
+			return false, err
+		}
+	}
+
+	return v, nil
+}
+
+// Get returns the item in the config store with the given key.
 func (s *Store) Get(key string) (string, error) {
 	if s == nil {
 		return "", ErrKeyNotFound

--- a/integration_tests/config_store/configstore.json
+++ b/integration_tests/config_store/configstore.json
@@ -1,3 +1,4 @@
 {
-  "twitter": "https://twitter.com/fastly"
+  "twitter": "https://twitter.com/fastly",
+  "empty-value": ""
 }

--- a/integration_tests/config_store/main_test.go
+++ b/integration_tests/config_store/main_test.go
@@ -16,6 +16,33 @@ func TestConfigStore(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	present, err := d.Has("missing-key")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if present {
+		t.Errorf("Has reported `true` for a missing key")
+	}
+
+	present, err := d.Has("empty-value")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !present {
+		t.Errorf("Has reported `false` for a `empty-key`")
+	}
+
+	present, err := d.Has("twitter")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !present {
+		t.Errorf("Missing key \"twitter\"")
+	}
+
 	twitter, err := d.Get("twitter")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/abi/fastly/hostcalls_guest.go
+++ b/internal/abi/fastly/hostcalls_guest.go
@@ -2443,7 +2443,7 @@ func (d *Dictionary) Get(key string) (string, error) {
 	return buf.ToString(), nil
 }
 
-// Check if a value exists.
+// Has returns whether a value exists.
 func (d *Dictionary) Has(key string) (bool, error) {
 	keyBuffer := prim.NewReadBufferFromString(key).Wstring()
 	var npointer prim.Usize = 0

--- a/internal/abi/fastly/hostcalls_guest.go
+++ b/internal/abi/fastly/hostcalls_guest.go
@@ -2443,6 +2443,32 @@ func (d *Dictionary) Get(key string) (string, error) {
 	return buf.ToString(), nil
 }
 
+// Check if a value exists.
+func (d *Dictionary) Has(key string) (bool, error) {
+	keyBuffer := prim.NewReadBufferFromString(key).Wstring()
+	var npointer prim.Usize = 0
+
+	if err := fastlyDictionaryGet(
+		d.h,
+		keyBuffer.Data, keyBuffer.Len,
+		prim.NullChar8Pointer(),
+		0,
+		prim.ToPointer(&npointer),
+	); err != FastlyStatusOK {
+		if err == FastlyStatusBufLen {
+			return true, nil
+		}
+
+		if err == FastlyStatusNone {
+			return false, nil
+		}
+
+		return false, err.toError()
+	}
+
+	return true, nil
+}
+
 // witx:
 //
 //	(module $fastly_geo

--- a/internal/abi/fastly/hostcalls_noguest.go
+++ b/internal/abi/fastly/hostcalls_noguest.go
@@ -301,6 +301,10 @@ func (d *Dictionary) Get(key string) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
+func (d *Dictionary) Has(key string) (bool, error) {
+	return false, fmt.Errorf("not implemented")
+}
+
 func GeoLookup(ip net.IP) ([]byte, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/internal/abi/prim/prim.go
+++ b/internal/abi/prim/prim.go
@@ -33,6 +33,11 @@ func ToPointer[T any](ptr *T) Pointer[T] {
 	return Pointer[T](uintptr(unsafe.Pointer(ptr)))
 }
 
+// NullPointer makes a null pointer to a byte buffer.
+func NullChar8Pointer() Pointer[Char8] {
+        return Pointer[Char8](uintptr(unsafe.Pointer(nil)))
+}
+
 // Wstring is a header for a string.
 type Wstring struct {
 	Data Pointer[U8]


### PR DESCRIPTION
Add a `Has` method to the `Dictionary` struct, which will avoid allocations when it's only desired to check if the value exists.

`Has` uses the same host call as `Get`, but gives it an empty buffer. This way it's able to inspect `FastlyStatus` to determine if the value was present, instead of actually copying the value over.
