### PR TITLE
configstore: Implement GetBytes() method

### DIFF
--- a/configstore/configstore.go
+++ b/configstore/configstore.go
@@ -86,26 +86,36 @@ func (s *Store) Has(key string) (bool, error) {
 	return v, nil
 }
 
-// Get returns the item in the config store with the given key.
-func (s *Store) Get(key string) (string, error) {
+// Get returns the item in the config store with the given key, as a byte slice.
+func (s *Store) GetBytes(key string) ([]byte, error) {
 	if s == nil {
-		return "", ErrKeyNotFound
+		return nil, ErrKeyNotFound
 	}
 
-	v, err := s.abiDict.Get(key)
+	v, err := s.abiDict.GetBytes(key)
 	if err != nil {
 		status, ok := fastly.IsFastlyError(err)
 		switch {
 		case ok && status == fastly.FastlyStatusBadf:
-			return "", ErrStoreNotFound
+			return nil, ErrStoreNotFound
 		case ok && status == fastly.FastlyStatusNone:
-			return "", ErrKeyNotFound
+			return nil, ErrKeyNotFound
 		case ok:
-			return "", fmt.Errorf("%w (%s)", ErrUnexpected, status)
+			return nil, fmt.Errorf("%w (%s)", ErrUnexpected, status)
 		default:
-			return "", err
+			return nil, err
 		}
 	}
 
 	return v, nil
+}
+
+// Get returns the item in the config store with the given key.
+func (s *Store) Get(key string) (string, error) {
+	buf, err := s.GetBytes(key)
+	if err != nil {
+		return "", err
+	}
+
+	return string(buf), nil
 }

--- a/internal/abi/fastly/hostcalls_guest.go
+++ b/internal/abi/fastly/hostcalls_guest.go
@@ -2425,8 +2425,8 @@ func fastlyDictionaryGet(
 	nWritten prim.Pointer[prim.Usize],
 ) FastlyStatus
 
-// Get the value for key, if it exists.
-func (d *Dictionary) Get(key string) (string, error) {
+// Get the value for key, as a byte slice, if it exists.
+func (d *Dictionary) GetBytes(key string) ([]byte, error) {
 	buf := prim.NewWriteBuffer(dictionaryValueMaxLen)
 	keyBuffer := prim.NewReadBufferFromString(key).Wstring()
 
@@ -2437,10 +2437,20 @@ func (d *Dictionary) Get(key string) (string, error) {
 		buf.Cap(),
 		prim.ToPointer(buf.NPointer()),
 	).toError(); err != nil {
+		return nil, err
+	}
+
+	return buf.AsBytes(), nil
+}
+
+// Get the value for key, if it exists.
+func (d *Dictionary) Get(key string) (string, error) {
+	buf, err := d.GetBytes(key)
+	if err != nil {
 		return "", err
 	}
 
-	return buf.ToString(), nil
+	return string(buf), nil
 }
 
 // Has returns whether a value exists.

--- a/internal/abi/fastly/hostcalls_noguest.go
+++ b/internal/abi/fastly/hostcalls_noguest.go
@@ -297,6 +297,10 @@ func OpenDictionary(name string) (*Dictionary, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
+func (d *Dictionary) GetBytes(key string) ([]byte, error) {
+	return []byte{}, fmt.Errorf("not implemented")
+}
+
 func (d *Dictionary) Get(key string) (string, error) {
 	return "", fmt.Errorf("not implemented")
 }

--- a/internal/abi/fastly/hostcalls_noguest.go
+++ b/internal/abi/fastly/hostcalls_noguest.go
@@ -298,7 +298,7 @@ func OpenDictionary(name string) (*Dictionary, error) {
 }
 
 func (d *Dictionary) GetBytes(key string) ([]byte, error) {
-	return []byte{}, fmt.Errorf("not implemented")
+	return nil, fmt.Errorf("not implemented")
 }
 
 func (d *Dictionary) Get(key string) (string, error) {


### PR DESCRIPTION
Similar to the Get() method, this one will return the byte slice as is from the Dictionary, without converting it to a string.  May be useful in cases where configuration is stored as binary blobs.