### PR TITLE
GHA: fix up actions, including integration_tests for PRs

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -1,5 +1,10 @@
 name: Build Examples
-on: [push]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
 jobs:
   build-examples:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -19,16 +19,11 @@ jobs:
             tinygo-version: '0.29.0'
 
     steps:
-      - name: Checkout fastly/compute-sdk-go
-        uses: actions/checkout@v4
-
-      - name: Install Go
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
-
-      - name: Install TinyGo
-        uses: ./.github/actions/install-tinygo
+      - uses: ./.github/actions/install-tinygo
         with:
           tinygo-version: ${{ matrix.tinygo-version }}
 

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -12,11 +12,11 @@ jobs:
       matrix:
         include:
           # Newest supported configuration
-          - go-version: '~1.21.0'
-            tinygo-version: '0.30.0'
+          - go-version: '1.22' # pairs with TinyGo 0.31.2
+            tinygo-version: '0.31.2'
           # Oldest supported configuration
-          - go-version: '~1.19.0'
-            tinygo-version: '0.28.1'
+          - go-version: '1.21' # pairs with TinyGo 0.29.0
+            tinygo-version: '0.29.0'
 
     steps:
       - name: Checkout fastly/compute-sdk-go

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -1,7 +1,8 @@
 name: Build Examples
 on: [push]
 jobs:
-  build-examples-tinygo:
+  build-examples:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
@@ -11,39 +12,34 @@ jobs:
           # Oldest supported configuration
           - go-version: '~1.19.0'
             tinygo-version: '0.28.1'
-    runs-on: ubuntu-latest
+
     steps:
       - name: Checkout fastly/compute-sdk-go
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-         go-version: ${{ matrix.go-version }}
+          go-version: ${{ matrix.go-version }}
+
       - name: Install TinyGo
         uses: ./.github/actions/install-tinygo
         with:
           tinygo-version: ${{ matrix.tinygo-version }}
-      - name: Build examples
+
+      - name: Build examples Go
+        env:
+          GOARCH: wasm
+          GOOS: wasip1
+        run: |
+          for i in _examples/*/; do
+            echo ${GITHUB_WORKSPACE}/$i
+            cd ${GITHUB_WORKSPACE}/$i && go build -tags fastlyinternaldebug
+          done
+
+      - name: Build examples TinyGo
         run: |
           for i in _examples/*/; do
             echo ${GITHUB_WORKSPACE}/$i
             cd ${GITHUB_WORKSPACE}/$i && tinygo build -target=wasi -tags fastlyinternaldebug
-          done
-  build-examples-go:
-    strategy:
-      matrix:
-        go-version: ['~1.21.0']
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout fastly/compute-sdk-go
-        uses: actions/checkout@v3
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-         go-version: ${{ matrix.go-version }}
-      - name: Build examples
-        run: |
-          for i in _examples/*/; do
-            echo ${GITHUB_WORKSPACE}/$i
-            cd ${GITHUB_WORKSPACE}/$i && env GOARCH=wasm GOOS=wasip1 go build -tags fastlyinternaldebug
           done

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -11,10 +11,10 @@ jobs:
       matrix:
         include:
           # Newest supported configuration
-          - go-version: 'stable'
-            tinygo-version: '0.31.0'
+          - go-version: '1.22' # pairs with TinyGo 0.31.2
+            tinygo-version: '0.31.2'
           # Oldest supported configuration
-          - go-version: 'oldstable'
+          - go-version: '1.20' # pairs with TinyGo 0.28.1
             tinygo-version: '0.28.1'
 
     steps:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -42,12 +42,16 @@ jobs:
           tar -xzf viceroy_v${{ env.VICEROY_VERSION }}_linux-amd64.tar.gz --directory $HOME/bin
           echo "$HOME/bin" >> $GITHUB_PATH
 
+      - name: Set up Wasmtime
+        uses: bytecodealliance/actions/wasmtime/setup@v1
+
       - name: Check our dependencies
         run: |
           go version
           tinygo version
           fastly version
           viceroy --version
+          wasmtime --version
 
       - name: Tests - Go
         run: go test -v -race -tags="fastlyinternaldebug nofastlyhostcalls" ./...

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request:
+
 jobs:
   integration-tests:
     runs-on: ubuntu-latest
@@ -14,8 +15,8 @@ jobs:
           - go-version: '1.22' # pairs with TinyGo 0.31.2
             tinygo-version: '0.31.2'
           # Oldest supported configuration
-          - go-version: '1.20' # pairs with TinyGo 0.28.1
-            tinygo-version: '0.28.1'
+          - go-version: '1.21' # pairs with TinyGo 0.29.0
+            tinygo-version: '0.29.0'
 
     steps:
       - name: Checkout fastly/compute-sdk-go

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -67,11 +67,7 @@ jobs:
           RUST_LOG: viceroy=info,viceroy-lib=info
           GOARCH: wasm
           GOOS: wasip1
-        run: |
-          for i in integration_tests/*/; do
-            echo ${GITHUB_WORKSPACE}/$i
-            cd ${GITHUB_WORKSPACE}/$i && env go test -v -tags="fastlyinternaldebug" -exec "viceroy run -C fastly.toml" ./...
-          done
+        run: go test -v -tags="fastlyinternaldebug" -exec "viceroy run -C fastly.toml" ./integration_tests/...
 
       - name: Integration Tests - TinyGo
         env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,8 +24,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
-      - name: Install TinyGo
-        uses: ./.github/actions/install-tinygo
+      - uses: ./.github/actions/install-tinygo
         with:
           tinygo-version: ${{ matrix.tinygo-version }}
 
@@ -50,6 +49,15 @@ jobs:
           fastly version
           viceroy --version
 
+      - name: Tests - Go
+        run: go test -v -race -tags="fastlyinternaldebug nofastlyhostcalls" ./...
+
+      - name: Tests - TinyGo
+        env:
+          GOARCH: wasm
+          GOOS: wasip1
+        run: tinygo test -v -tags="fastlyinternaldebug nofastlyhostcalls" ./...
+
       - name: Integration Tests - Go
         env:
           RUST_LOG: viceroy=info,viceroy-lib=info
@@ -58,10 +66,10 @@ jobs:
         run: |
           for i in integration_tests/*/; do
             echo ${GITHUB_WORKSPACE}/$i
-            cd ${GITHUB_WORKSPACE}/$i && env go test -v -tags fastlyinternaldebug -exec "viceroy run -C fastly.toml" ./...
+            cd ${GITHUB_WORKSPACE}/$i && env go test -v -tags="fastlyinternaldebug" -exec "viceroy run -C fastly.toml" ./...
           done
 
       - name: Integration Tests - TinyGo
         env:
           RUST_LOG: viceroy=info,viceroy-lib=info
-        run: tinygo test -v -tags fastlyinternaldebug -target=fastly-compute.json ./integration_tests/...
+        run: tinygo test -v -tags="fastlyinternaldebug" -target=fastly-compute.json ./integration_tests/...

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,7 +40,7 @@ jobs:
           VICEROY_VERSION: 0.9.7
         run: |
           echo "Install Viceroy ${{ env.VICEROY_VERSION }}..."
-          wget https://github.com/fastly/Viceroy/releases/download/v${{ env.VICEROY_VERSION }}/viceroy_v${{ env.VICEROY_VERSION }}_linux-amd64.tar.gz
+          wget --no-verbose https://github.com/fastly/Viceroy/releases/download/v${{ env.VICEROY_VERSION }}/viceroy_v${{ env.VICEROY_VERSION }}_linux-amd64.tar.gz
           mkdir -p $HOME/bin
           tar -xzf viceroy_v${{ env.VICEROY_VERSION }}_linux-amd64.tar.gz --directory $HOME/bin
           echo "$HOME/bin" >> $GITHUB_PATH
@@ -55,12 +55,10 @@ jobs:
       - name: Run Integration Tests Go
         env:
           RUST_LOG: viceroy=info,viceroy-lib=info
-          GOARCH: wasm
-          GOOS: wasip1
         run: |
           for i in integration_tests/*/; do
             echo ${GITHUB_WORKSPACE}/$i
-            cd ${GITHUB_WORKSPACE}/$i && go test -v -tags fastlyinternaldebug -exec "viceroy run -C fastly.toml" ./...
+            cd ${GITHUB_WORKSPACE}/$i && env GOARCH=wasm GOOS=wasip1 go test -v -tags fastlyinternaldebug -exec "viceroy run -C fastly.toml" ./...
           done
 
       - name: Run Integration Tests TinyGo

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -19,11 +19,8 @@ jobs:
             tinygo-version: '0.29.0'
 
     steps:
-      - name: Checkout fastly/compute-sdk-go
-        uses: actions/checkout@v4
-
-      - name: Install Go
-        uses: actions/setup-go@v5
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
 
@@ -53,16 +50,18 @@ jobs:
           fastly version
           viceroy --version
 
-      - name: Run Integration Tests Go
+      - name: Integration Tests - Go
         env:
           RUST_LOG: viceroy=info,viceroy-lib=info
+          GOARCH: wasm
+          GOOS: wasip1
         run: |
           for i in integration_tests/*/; do
             echo ${GITHUB_WORKSPACE}/$i
-            cd ${GITHUB_WORKSPACE}/$i && env GOARCH=wasm GOOS=wasip1 go test -v -tags fastlyinternaldebug -exec "viceroy run -C fastly.toml" ./...
+            cd ${GITHUB_WORKSPACE}/$i && env go test -v -tags fastlyinternaldebug -exec "viceroy run -C fastly.toml" ./...
           done
 
-      - name: Run Integration Tests TinyGo
+      - name: Integration Tests - TinyGo
         env:
           RUST_LOG: viceroy=info,viceroy-lib=info
         run: tinygo test -v -tags fastlyinternaldebug -target=fastly-compute.json ./integration_tests/...

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,71 +1,69 @@
 name: Integration Tests
-on: [push]
-env:
-  VICEROY_VERSION: 0.9.6
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
-  integration-tests-tinygo:
+  integration-tests:
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
           # Newest supported configuration
-          - go-version: '~1.21.0'
-            tinygo-version: '0.30.0'
+          - go-version: 'stable'
+            tinygo-version: '0.31.0'
           # Oldest supported configuration
-          - go-version: '~1.19.0'
+          - go-version: 'oldstable'
             tinygo-version: '0.28.1'
-    runs-on: ubuntu-latest
+
     steps:
       - name: Checkout fastly/compute-sdk-go
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
       - name: Install Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
+
       - name: Install TinyGo
         uses: ./.github/actions/install-tinygo
         with:
           tinygo-version: ${{ matrix.tinygo-version }}
+
       - name: Setup Fastly CLI
-        uses: fastly/compute-actions/setup@v5
+        uses: fastly/compute-actions/setup@v7
+
       - name: Install Viceroy ${{ env.VICEROY_VERSION }}
+        shell: 'bash'
+        env:
+          VICEROY_VERSION: 0.9.7
         run: |
           echo "Install Viceroy ${{ env.VICEROY_VERSION }}..."
           wget https://github.com/fastly/Viceroy/releases/download/v${{ env.VICEROY_VERSION }}/viceroy_v${{ env.VICEROY_VERSION }}_linux-amd64.tar.gz
           mkdir -p $HOME/bin
           tar -xzf viceroy_v${{ env.VICEROY_VERSION }}_linux-amd64.tar.gz --directory $HOME/bin
           echo "$HOME/bin" >> $GITHUB_PATH
-        shell: "bash"
+
       - name: Check our dependencies
         run: |
           go version
           tinygo version
           fastly version
           viceroy --version
-      - name: Run Integration Tests
-        run: RUST_LOG="viceroy=info,viceroy-lib=info" tinygo test -v -target=fastly-compute.json -tags fastlyinternaldebug ./integration_tests/...
-  integration-tests-go:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout fastly/compute-sdk-go
-        uses: actions/checkout@v3
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '~1.21.0'
-      - name: Setup Fastly CLI
-        uses: fastly/compute-actions/setup@v5
-      - name: Install Viceroy ${{ env.VICEROY_VERSION }}
+
+      - name: Run Integration Tests Go
+        env:
+          RUST_LOG: viceroy=info,viceroy-lib=info
+          GOARCH: wasm
+          GOOS: wasip1
         run: |
-          echo "Install Viceroy ${{ env.VICEROY_VERSION }}..."
-          wget https://github.com/fastly/Viceroy/releases/download/v${{ env.VICEROY_VERSION }}/viceroy_v${{ env.VICEROY_VERSION }}_linux-amd64.tar.gz
-          mkdir -p $HOME/bin
-          tar -xzf viceroy_v${{ env.VICEROY_VERSION }}_linux-amd64.tar.gz --directory $HOME/bin
-          echo "$HOME/bin" >> $GITHUB_PATH
-        shell: "bash"
-      - name: Check our dependencies
-        run: |
-          go version
-          fastly version
-          viceroy --version
-      - name: Run Integration Tests
-        run: RUST_LOG="viceroy=info,viceroy-lib=info" GOARCH=wasm GOOS=wasip1 go test -tags fastlyinternaldebug -exec "viceroy run -C fastly.toml" -v ./integration_tests/...
+          for i in integration_tests/*/; do
+            echo ${GITHUB_WORKSPACE}/$i
+            cd ${GITHUB_WORKSPACE}/$i && go test -v -tags fastlyinternaldebug -exec "viceroy run -C fastly.toml" ./...
+          done
+
+      - name: Run Integration Tests TinyGo
+        env:
+          RUST_LOG: viceroy=info,viceroy-lib=info
+        run: tinygo test -v -tags fastlyinternaldebug -target=fastly-compute.json ./integration_tests/...

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,10 +44,14 @@ jobs:
         with:
           tinygo-version: '0.31.2'
 
+      - name: Set up Wasmtime
+        uses: bytecodealliance/actions/wasmtime/setup@v1
+
       - name: Check our dependencies
         run: |
           go version
           tinygo version
+          wasmtime --version
 
       - name: Tests - Go
         run: go test -v -race -tags="fastlyinternaldebug nofastlyhostcalls" ./...

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,4 +41,5 @@ jobs:
         with:
           go-version: stable
 
-      - run: go test -race ./...
+      - name: Run tests that only require Go
+        run: go test -race ./...

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -40,6 +40,20 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: stable
+      - uses: ./.github/actions/install-tinygo
+        with:
+          tinygo-version: '0.31.2'
 
-      - name: Run tests that only require Go
-        run: go test -race ./...
+      - name: Check our dependencies
+        run: |
+          go version
+          tinygo version
+
+      - name: Tests - Go
+        run: go test -v -race -tags="fastlyinternaldebug nofastlyhostcalls" ./...
+
+      - name: Tests - TinyGo
+        env:
+          GOARCH: wasm
+          GOOS: wasip1
+        run: tinygo test -v -tags="fastlyinternaldebug nofastlyhostcalls" ./...

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -4,35 +4,41 @@ on:
     branches:
       - main
   pull_request:
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: stable
+
       - name: go vet
         run: go vet ./...
+
       - name: staticcheck
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest
           staticcheck ./...
+
       - name: nilness
         run: |
           go install golang.org/x/tools/go/analysis/passes/nilness/cmd/nilness@master
           nilness ./...
+
       - name: ineffassign
         run: |
           go install github.com/gordonklaus/ineffassign@latest
           ineffassign ./...
+
   test:
     needs: [lint]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-go@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: stable
-      - name: go test
-        run: go test -race ./...
+
+      - run: go test -race ./...


### PR DESCRIPTION
Actions now runs tests, integration tests, and builds examples on pushes and PRs.

Some of the Go/TinyGo separate actions were consolidated to do both to save time on setup/teardown.

Versions of included actions were bumped.