### PR TITLE
Use known and adaptive buffer sizes to lower generated garbage

### DIFF
--- a/.github/actions/install-tinygo/action.yml
+++ b/.github/actions/install-tinygo/action.yml
@@ -10,7 +10,7 @@ runs:
   steps:
     - run: |
         echo "Install TinyGo ${{ inputs.tinygo-version }}..."
-        wget https://github.com/tinygo-org/tinygo/releases/download/v${{ inputs.tinygo-version }}/tinygo_${{ inputs.tinygo-version }}_amd64.deb
+        wget --no-verbose https://github.com/tinygo-org/tinygo/releases/download/v${{ inputs.tinygo-version }}/tinygo_${{ inputs.tinygo-version }}_amd64.deb
         sudo dpkg -i tinygo_${{ inputs.tinygo-version }}_amd64.deb
         echo "/usr/local/tinygo/bin" >> $GITHUB_PATH
       shell: "bash"

--- a/fsthttp/limits.go
+++ b/fsthttp/limits.go
@@ -29,21 +29,23 @@ func (limits *Limits) SetMaxHeaderValueLen(len int) {
 }
 
 // MaxMethodLen gets the request method limit
+// Deprecated: the limit is not enforced, buffer sizing is adaptive.
 func (limits *Limits) MaxMethodLen() int {
 	return limits.maxMethodLen
 }
 
 // SetMaxMethodLen sets the request method limit
-func (limits *Limits) SetMaxMethodLen(len int) {
-	limits.maxMethodLen = len
+// Deprecated: the limit is not reset, buffer sizing is adaptive.
+func (limits *Limits) SetMaxMethodLen(_ int) {
 }
 
 // MaxURLLen gets the request URL limit
+// Deprecated: the limit is not enforced, buffer sizing is adaptive.
 func (limits *Limits) MaxURLLen() int {
 	return limits.maxURLLen
 }
 
 // SetMaxURLLen sets the request URL limit
-func (limits *Limits) SetMaxURLLen(len int) {
-	limits.maxURLLen = len
+// Deprecated: the limit is not reset, buffer sizing is adaptive.
+func (limits *Limits) SetMaxURLLen(_ int) {
 }

--- a/fsthttp/request.go
+++ b/fsthttp/request.go
@@ -17,10 +17,10 @@ import (
 
 // RequestLimits are the limits for the components of an HTTP request.
 var RequestLimits = Limits{
-	maxHeaderNameLen:  fastly.DefaultMaxHeaderNameLen,
-	maxHeaderValueLen: fastly.DefaultMaxHeaderValueLen,
-	maxMethodLen:      fastly.DefaultMaxMethodLen,
-	maxURLLen:         fastly.DefaultMaxURLLen,
+	maxHeaderNameLen:  fastly.DefaultLargeBufLen,
+	maxHeaderValueLen: fastly.DefaultLargeBufLen,
+	maxMethodLen:      fastly.DefaultMediumBufLen,
+	maxURLLen:         fastly.DefaultLargeBufLen,
 }
 
 // Request represents an HTTP request received by this server from a requesting

--- a/fsthttp/request.go
+++ b/fsthttp/request.go
@@ -133,12 +133,12 @@ func newClientRequest() (*Request, error) {
 		return nil, fmt.Errorf("get client request and body: %w", err)
 	}
 
-	method, err := abiReq.GetMethod(RequestLimits.maxMethodLen)
+	method, err := abiReq.GetMethod()
 	if err != nil {
 		return nil, fmt.Errorf("get method: %w", err)
 	}
 
-	uri, err := abiReq.GetURI(RequestLimits.maxURLLen)
+	uri, err := abiReq.GetURI()
 	if err != nil {
 		return nil, fmt.Errorf("get URI: %w", err)
 	}

--- a/fsthttp/response.go
+++ b/fsthttp/response.go
@@ -12,8 +12,8 @@ import (
 
 // ResponseLimits are the limits for the components of an HTTP response.
 var ResponseLimits = Limits{
-	maxHeaderNameLen:  fastly.DefaultMaxHeaderNameLen,
-	maxHeaderValueLen: fastly.DefaultMaxHeaderValueLen,
+	maxHeaderNameLen:  fastly.DefaultLargeBufLen,
+	maxHeaderValueLen: fastly.DefaultLargeBufLen,
 }
 
 // Response to an outgoing HTTP request made by this server.

--- a/internal/abi/fastly/hostcalls_guest.go
+++ b/internal/abi/fastly/hostcalls_guest.go
@@ -711,8 +711,7 @@ func (r *HTTPRequest) GetHeaderNames(maxHeaderNameLen int) *Values {
 
 		return fastlyHTTPReqHeaderNamesGet(
 			r.h,
-			prim.ToPointer(buf),
-			bufLen,
+			prim.ToPointer(buf), bufLen,
 			cursor,
 			prim.ToPointer(endingCursorOut),
 			prim.ToPointer(nwrittenOut),
@@ -755,8 +754,7 @@ func GetOriginalHeaderNames(maxHeaderNameLen int) *Values {
 	) FastlyStatus {
 
 		return fastlyHTTPReqOriginalHeaderNamesGet(
-			prim.ToPointer(buf),
-			bufLen,
+			prim.ToPointer(buf), bufLen,
 			cursor,
 			prim.ToPointer(endingCursorOut),
 			prim.ToPointer(nwrittenOut),
@@ -873,8 +871,7 @@ func (r *HTTPRequest) GetHeaderValues(name string, maxHeaderValueLen int) *Value
 		return fastlyHTTPReqHeaderValuesGet(
 			r.h,
 			nameBuffer.Data, nameBuffer.Len,
-			prim.ToPointer(buf),
-			bufLen,
+			prim.ToPointer(buf), bufLen,
 			cursor,
 			prim.ToPointer(endingCursorOut),
 			prim.ToPointer(nwrittenOut),
@@ -1541,7 +1538,12 @@ func HandoffFanout(backend string) error {
 //
 //go:wasmimport fastly_http_req register_dynamic_backend
 //go:noescape
-func fastlyRegisterDynamicBackend(nameData prim.Pointer[prim.U8], nameLen prim.Usize, targetData prim.Pointer[prim.U8], targetLen prim.Usize, mask backendConfigOptionsMask, opts prim.Pointer[backendConfigOptions]) FastlyStatus
+func fastlyRegisterDynamicBackend(
+	nameData prim.Pointer[prim.U8], nameLen prim.Usize,
+	targetData prim.Pointer[prim.U8], targetLen prim.Usize,
+	mask backendConfigOptionsMask,
+	opts prim.Pointer[backendConfigOptions],
+) FastlyStatus
 
 func RegisterDynamicBackend(name string, target string, opts *BackendConfigOptions) error {
 	nameBuffer := prim.NewReadBufferFromString(name).Wstring()
@@ -1570,7 +1572,10 @@ func RegisterDynamicBackend(name string, target string, opts *BackendConfigOptio
 //
 //go:wasmimport fastly_backend exists
 //go:noescape
-func fastlyBackendExists(nameData prim.Pointer[prim.U8], nameLen prim.Usize, exists prim.Pointer[prim.U32]) FastlyStatus
+func fastlyBackendExists(
+	nameData prim.Pointer[prim.U8], nameLen prim.Usize,
+	exists prim.Pointer[prim.U32],
+) FastlyStatus
 
 func BackendExists(name string) (bool, error) {
 	var exists prim.U32
@@ -1596,7 +1601,10 @@ func BackendExists(name string) (bool, error) {
 //
 //go:wasmimport fastly_backend is_healthy
 //go:noescape
-func fastlyBackendIsHealthy(nameData prim.Pointer[prim.U8], nameLen prim.Usize, healthy prim.Pointer[prim.U32]) FastlyStatus
+func fastlyBackendIsHealthy(
+	nameData prim.Pointer[prim.U8], nameLen prim.Usize,
+	healthy prim.Pointer[prim.U32],
+) FastlyStatus
 
 func BackendIsHealthy(name string) (BackendHealth, error) {
 	var health prim.U32
@@ -1622,7 +1630,10 @@ func BackendIsHealthy(name string) (BackendHealth, error) {
 //
 //go:wasmimport fastly_backend is_dynamic
 //go:noescape
-func fastlyBackendIsDynamic(nameData prim.Pointer[prim.U8], nameLen prim.Usize, dynamic prim.Pointer[prim.U32]) FastlyStatus
+func fastlyBackendIsDynamic(
+	nameData prim.Pointer[prim.U8], nameLen prim.Usize,
+	dynamic prim.Pointer[prim.U32],
+) FastlyStatus
 
 func BackendIsDynamic(name string) (bool, error) {
 	var dynamic prim.U32
@@ -1719,7 +1730,10 @@ func BackendGetOverrideHost(name string) (string, error) {
 //
 //go:wasmimport fastly_backend get_port
 //go:noescape
-func fastlyBackendGetPort(nameData prim.Pointer[prim.U8], nameLen prim.Usize, port prim.Pointer[prim.U32]) FastlyStatus
+func fastlyBackendGetPort(
+	nameData prim.Pointer[prim.U8], nameLen prim.Usize,
+	port prim.Pointer[prim.U32],
+) FastlyStatus
 
 func BackendGetPort(name string) (int, error) {
 	var port prim.U32
@@ -1745,7 +1759,10 @@ func BackendGetPort(name string) (int, error) {
 //
 //go:wasmimport fastly_backend get_connect_timeout_ms
 //go:noescape
-func fastlyBackendGetConnectTimeoutMs(nameData prim.Pointer[prim.U8], nameLen prim.Usize, timeout prim.Pointer[prim.U32]) FastlyStatus
+func fastlyBackendGetConnectTimeoutMs(
+	nameData prim.Pointer[prim.U8], nameLen prim.Usize,
+	timeout prim.Pointer[prim.U32],
+) FastlyStatus
 
 func BackendGetConnectTimeout(name string) (time.Duration, error) {
 	var timeout prim.U32
@@ -1771,7 +1788,10 @@ func BackendGetConnectTimeout(name string) (time.Duration, error) {
 //
 //go:wasmimport fastly_backend get_first_byte_timeout_ms
 //go:noescape
-func fastlyBackendGetFirstByteTimeoutMs(nameData prim.Pointer[prim.U8], nameLen prim.Usize, timeout prim.Pointer[prim.U32]) FastlyStatus
+func fastlyBackendGetFirstByteTimeoutMs(
+	nameData prim.Pointer[prim.U8], nameLen prim.Usize,
+	timeout prim.Pointer[prim.U32],
+) FastlyStatus
 
 func BackendGetFirstByteTimeout(name string) (time.Duration, error) {
 	var timeout prim.U32
@@ -1797,7 +1817,10 @@ func BackendGetFirstByteTimeout(name string) (time.Duration, error) {
 //
 //go:wasmimport fastly_backend get_between_bytes_timeout_ms
 //go:noescape
-func fastlyBackendGetBetweenBytesTimeoutMs(nameData prim.Pointer[prim.U8], nameLen prim.Usize, timeout prim.Pointer[prim.U32]) FastlyStatus
+func fastlyBackendGetBetweenBytesTimeoutMs(
+	nameData prim.Pointer[prim.U8], nameLen prim.Usize,
+	timeout prim.Pointer[prim.U32],
+) FastlyStatus
 
 func BackendGetBetweenBytesTimeout(name string) (time.Duration, error) {
 	var timeout prim.U32
@@ -1823,7 +1846,10 @@ func BackendGetBetweenBytesTimeout(name string) (time.Duration, error) {
 //
 //go:wasmimport fastly_backend is_ssl
 //go:noescape
-func fastlyBackendIsSSL(nameData prim.Pointer[prim.U8], nameLen prim.Usize, ssl prim.Pointer[prim.U32]) FastlyStatus
+func fastlyBackendIsSSL(
+	nameData prim.Pointer[prim.U8], nameLen prim.Usize,
+	ssl prim.Pointer[prim.U32],
+) FastlyStatus
 
 func BackendIsSSL(name string) (bool, error) {
 	var ssl prim.U32
@@ -1849,7 +1875,10 @@ func BackendIsSSL(name string) (bool, error) {
 //
 //go:wasmimport fastly_backend get_ssl_min_version
 //go:noescape
-func fastlyBackendGetSSLMinVersion(nameData prim.Pointer[prim.U8], nameLen prim.Usize, version prim.Pointer[prim.U32]) FastlyStatus
+func fastlyBackendGetSSLMinVersion(
+	nameData prim.Pointer[prim.U8], nameLen prim.Usize,
+	version prim.Pointer[prim.U32],
+) FastlyStatus
 
 func BackendGetSSLMinVersion(name string) (TLSVersion, error) {
 	var version prim.U32
@@ -1875,7 +1904,10 @@ func BackendGetSSLMinVersion(name string) (TLSVersion, error) {
 //
 //go:wasmimport fastly_backend get_ssl_max_version
 //go:noescape
-func fastlyBackendGetSSLMaxVersion(nameData prim.Pointer[prim.U8], nameLen prim.Usize, version prim.Pointer[prim.U32]) FastlyStatus
+func fastlyBackendGetSSLMaxVersion(
+	nameData prim.Pointer[prim.U8], nameLen prim.Usize,
+	version prim.Pointer[prim.U32],
+) FastlyStatus
 
 func BackendGetSSLMaxVersion(name string) (TLSVersion, error) {
 	var version prim.U32
@@ -2496,10 +2528,8 @@ func (d *Dictionary) Has(key string) (bool, error) {
 //go:wasmimport fastly_geo lookup
 //go:noescape
 func fastlyGeoLookup(
-	addrOctets prim.Pointer[prim.Char8],
-	addLen prim.Usize,
-	buf prim.Pointer[prim.Char8],
-	bufLen prim.Usize,
+	addrOctets prim.Pointer[prim.Char8], addrLen prim.Usize,
+	buf prim.Pointer[prim.Char8], bufLen prim.Usize,
 	nWrittenOut prim.Pointer[prim.Usize],
 ) FastlyStatus
 
@@ -2512,10 +2542,8 @@ func GeoLookup(ip net.IP) ([]byte, error) {
 	addrOctets := prim.NewReadBufferFromBytes(ip)
 
 	if err := fastlyGeoLookup(
-		prim.ToPointer(addrOctets.Char8Pointer()),
-		addrOctets.Len(),
-		prim.ToPointer(buf.Char8Pointer()),
-		buf.Cap(),
+		prim.ToPointer(addrOctets.Char8Pointer()), addrOctets.Len(),
+		prim.ToPointer(buf.Char8Pointer()), buf.Cap(),
 		prim.ToPointer(buf.NPointer()),
 	).toError(); err != nil {
 		return nil, err
@@ -3458,7 +3486,11 @@ func (o *PurgeOptions) SoftPurge(v bool) {
 //
 //go:wasmimport fastly_purge purge_surrogate_key
 //go:noescape
-func fastlyPurgeSurrogateKey(surrogateKeyData prim.Pointer[prim.U8], surrogateKeyLen prim.Usize, mask purgeOptionsMask, opts prim.Pointer[purgeOptions]) FastlyStatus
+func fastlyPurgeSurrogateKey(
+	surrogateKeyData prim.Pointer[prim.U8], surrogateKeyLen prim.Usize,
+	mask purgeOptionsMask,
+	opts prim.Pointer[purgeOptions],
+) FastlyStatus
 
 func PurgeSurrogateKey(surrogateKey string, opts PurgeOptions) error {
 	surrogateKeyBuffer := prim.NewReadBufferFromString(surrogateKey).Wstring()
@@ -3487,8 +3519,7 @@ func PurgeSurrogateKey(surrogateKey string, opts PurgeOptions) error {
 //go:noescape
 func fastlyDeviceDetectionLookup(
 	userAgentData prim.Pointer[prim.U8], userAgentLen prim.Usize,
-	buf prim.Pointer[prim.Char8],
-	bufLen prim.Usize,
+	buf prim.Pointer[prim.Char8], bufLen prim.Usize,
 	nWritten prim.Pointer[prim.Usize],
 ) FastlyStatus
 

--- a/internal/abi/fastly/hostcalls_guest.go
+++ b/internal/abi/fastly/hostcalls_guest.go
@@ -3306,7 +3306,7 @@ func fastlyCacheGetUserMetadata(
 ) FastlyStatus
 
 func (c *CacheEntry) UserMetadata() ([]byte, error) {
-	n := DefaultSmallBufLen
+	n := DefaultMediumBufLen
 alloc:
 	buf := prim.NewWriteBuffer(n) // Longest (unknown)
 	status := fastlyCacheGetUserMetadata(
@@ -3541,7 +3541,7 @@ func fastlyDeviceDetectionLookup(
 
 func DeviceLookup(userAgent string) ([]byte, error) {
 	userAgentBuffer := prim.NewReadBufferFromString(userAgent).Wstring()
-	n := DefaultSmallBufLen // Longest JSON of https://www.fastly.com/documentation/reference/vcl/variables/client-request/client-identified/
+	n := DefaultMediumBufLen // Longest JSON of https://www.fastly.com/documentation/reference/vcl/variables/client-request/client-identified/
 alloc:
 	buf := prim.NewWriteBuffer(n)
 	status := fastlyDeviceDetectionLookup(

--- a/internal/abi/fastly/hostcalls_guest.go
+++ b/internal/abi/fastly/hostcalls_guest.go
@@ -1021,15 +1021,21 @@ func fastlyHTTPReqMethodGet(
 ) FastlyStatus
 
 // GetMethod returns the HTTP method of the request.
-func (r *HTTPRequest) GetMethod(maxMethodLen int) (string, error) {
-	buf := prim.NewWriteBuffer(maxMethodLen)
-
-	if err := fastlyHTTPReqMethodGet(
+func (r *HTTPRequest) GetMethod() (string, error) {
+	n := DefaultMaxMethodLen
+alloc:
+	buf := prim.NewWriteBuffer(n)
+	status := fastlyHTTPReqMethodGet(
 		r.h,
 		prim.ToPointer(buf.Char8Pointer()),
 		buf.Cap(),
 		prim.ToPointer(buf.NPointer()),
-	).toError(); err != nil {
+	)
+	if status == FastlyStatusBufLen && buf.NValue() > 0 {
+		n = int(buf.NValue())
+		goto alloc // avoid all the allocations of a new stack, etc.
+	}
+	if err := status.toError(); err != nil {
 		return "", err
 	}
 
@@ -1081,15 +1087,21 @@ func fastlyHTTPReqURIGet(
 ) FastlyStatus
 
 // GetURI returns the fully qualified URI of the request.
-func (r *HTTPRequest) GetURI(maxURLLen int) (string, error) {
-	buf := prim.NewWriteBuffer(maxURLLen)
-
-	if err := fastlyHTTPReqURIGet(
+func (r *HTTPRequest) GetURI() (string, error) {
+	n := DefaultMaxURLLen
+alloc:
+	buf := prim.NewWriteBuffer(n)
+	status := fastlyHTTPReqURIGet(
 		r.h,
 		prim.ToPointer(buf.Char8Pointer()),
 		buf.Cap(),
 		prim.ToPointer(buf.NPointer()),
-	).toError(); err != nil {
+	)
+	if status == FastlyStatusBufLen && buf.NValue() > 0 {
+		n = int(buf.NValue())
+		goto alloc // avoid all the allocations of a new stack, etc.
+	}
+	if err := status.toError(); err != nil {
 		return "", err
 	}
 

--- a/internal/abi/fastly/hostcalls_guest.go
+++ b/internal/abi/fastly/hostcalls_guest.go
@@ -902,7 +902,7 @@ func fastlyHTTPReqHeaderValuesSet(
 func (r *HTTPRequest) SetHeaderValues(name string, values []string) error {
 	var buf bytes.Buffer
 	for _, value := range values {
-		fmt.Fprint(&buf, value)
+		buf.WriteString(value)
 		buf.WriteByte(0)
 	}
 
@@ -2118,7 +2118,7 @@ func fastlyHTTPRespHeaderValuesSet(
 func (r *HTTPResponse) SetHeaderValues(name string, values []string) error {
 	var buf bytes.Buffer
 	for _, value := range values {
-		fmt.Fprint(&buf, value)
+		buf.WriteString(value)
 		buf.WriteByte(0)
 	}
 

--- a/internal/abi/fastly/hostcalls_guest.go
+++ b/internal/abi/fastly/hostcalls_guest.go
@@ -648,7 +648,7 @@ alloc:
 	)
 	if status == FastlyStatusBufLen && buf.NValue() > 0 {
 		n = int(buf.NValue())
-		goto alloc // avoid all the allocations of a new stack, etc.
+		goto alloc // goto saves having to allocate a function closure and avoids having to duplicate the hostcall
 	}
 	if err := status.toError(); err != nil {
 		return nil, err
@@ -1041,7 +1041,7 @@ alloc:
 	)
 	if status == FastlyStatusBufLen && buf.NValue() > 0 {
 		n = int(buf.NValue())
-		goto alloc // avoid all the allocations of a new stack, etc.
+		goto alloc // goto saves having to allocate a function closure and avoids having to duplicate the hostcall
 	}
 	if err := status.toError(); err != nil {
 		return "", err
@@ -1107,7 +1107,7 @@ alloc:
 	)
 	if status == FastlyStatusBufLen && buf.NValue() > 0 {
 		n = int(buf.NValue())
-		goto alloc // avoid all the allocations of a new stack, etc.
+		goto alloc // goto saves having to allocate a function closure and avoids having to duplicate the hostcall
 	}
 	if err := status.toError(); err != nil {
 		return "", err
@@ -2493,7 +2493,7 @@ alloc:
 	)
 	if status == FastlyStatusBufLen && buf.NValue() > 0 {
 		n = int(buf.NValue())
-		goto alloc // avoid all the allocations of a new stack, etc.
+		goto alloc // goto saves having to allocate a function closure and avoids having to duplicate the hostcall
 	}
 
 	if err := status.toError(); err != nil {
@@ -2578,7 +2578,7 @@ alloc:
 	)
 	if status == FastlyStatusBufLen && buf.NValue() > 0 {
 		n = int(buf.NValue())
-		goto alloc // avoid all the allocations of a new stack, etc.
+		goto alloc // goto saves having to allocate a function closure and avoids having to duplicate the hostcall
 	}
 	if err := status.toError(); err != nil {
 		return nil, err
@@ -2863,7 +2863,7 @@ alloc:
 	)
 	if status == FastlyStatusBufLen && buf.NValue() > 0 {
 		n = int(buf.NValue())
-		goto alloc // avoid all the allocations of a new stack, etc.
+		goto alloc // goto saves having to allocate a function closure and avoids having to duplicate the hostcall
 	}
 
 	if err := status.toError(); err != nil {
@@ -3317,7 +3317,7 @@ alloc:
 	)
 	if status == FastlyStatusBufLen && buf.NValue() > 0 {
 		n = int(buf.NValue())
-		goto alloc // avoid all the allocations of a new stack, etc.
+		goto alloc // goto saves having to allocate a function closure and avoids having to duplicate the hostcall
 	}
 	if err := status.toError(); err != nil {
 		return nil, err
@@ -3552,7 +3552,7 @@ alloc:
 	)
 	if status == FastlyStatusBufLen && buf.NValue() > 0 {
 		n = int(buf.NValue())
-		goto alloc // avoid all the allocations of a new stack, etc.
+		goto alloc // goto saves having to allocate a function closure and avoids having to duplicate the hostcall
 	}
 	if err := status.toError(); err != nil {
 		return nil, err

--- a/internal/abi/fastly/hostcalls_noguest.go
+++ b/internal/abi/fastly/hostcalls_noguest.go
@@ -119,7 +119,7 @@ func (r *HTTPRequest) RemoveHeader(name string) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (r *HTTPRequest) GetMethod(maxMethodLen int) (string, error) {
+func (r *HTTPRequest) GetMethod() (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 
@@ -127,7 +127,7 @@ func (r *HTTPRequest) SetMethod(method string) error {
 	return fmt.Errorf("not implemented")
 }
 
-func (r *HTTPRequest) GetURI(maxURLLen int) (string, error) {
+func (r *HTTPRequest) GetURI() (string, error) {
 	return "", fmt.Errorf("not implemented")
 }
 

--- a/internal/abi/fastly/types.go
+++ b/internal/abi/fastly/types.go
@@ -185,8 +185,9 @@ func IsFastlyError(err error) (FastlyStatus, bool) {
 }
 
 const (
-	ipBufLen  = 16  // known size for IP address buffers
-	dnsBufLen = 256 // known size for "DNS" values, enough to hold the longest possible hostname or domain name
+	ipBufLen              = 16   // known size for IP address buffers
+	dnsBufLen             = 256  // known size for "DNS" values, enough to hold the longest possible hostname or domain name
+	dictionaryValueMaxLen = 8192 // known size for maximum config store value https://docs.fastly.com/en/guides/about-edge-dictionaries#limitations-and-considerations
 
 	DefaultSmallBufLen  = 128  // default size for "typically-small" values with variable sizes: HTTP methods, header names, tls protocol names, cipher suites
 	DefaultMediumBufLen = 1024 // default size for values between small and large with variable sizes

--- a/internal/abi/fastly/types.go
+++ b/internal/abi/fastly/types.go
@@ -316,19 +316,12 @@ const (
 )
 
 const (
-	// DefaultMaxHeaderNameLen is the default header name length limit
-	DefaultMaxHeaderNameLen = 8192
-	// DefaultMaxHeaderValueLen is the default header value length limit
-	DefaultMaxHeaderValueLen = 8192
-	// DefaultMaxMethodLen is the default method length limit
-	DefaultMaxMethodLen = 1024
-	// DefaultMaxURLLen is the default URL length limit
-	DefaultMaxURLLen = 8192
+	ipBufLen  = 16  // known size for IP address buffers
+	dnsBufLen = 256 // known size for "DNS" values, enough to hold the longest possible hostname or domain name
 
-	dictionaryValueMaxLen = 8192 // https://docs.fastly.com/en/guides/about-edge-dictionaries#limitations-and-considerations
-	defaultBufferLen      = 16 * 1024
-
-	initialSecretLen = 1024
+	DefaultSmallBufLen  = 128  // default size for "typically-small" values with variable sizes: HTTP methods, header names, tls protocol names, cipher suites
+	DefaultMediumBufLen = 1024 // default size for values between small and large with variable sizes
+	DefaultLargeBufLen  = 8192 // default size for "typically-large" values with variable sizes; header values, URLs.
 )
 
 // CacheOverrideOptions collects specific, caching-related options for outbound

--- a/internal/abi/fastly/types.go
+++ b/internal/abi/fastly/types.go
@@ -184,6 +184,15 @@ func IsFastlyError(err error) (FastlyStatus, bool) {
 	}
 }
 
+const (
+	ipBufLen  = 16  // known size for IP address buffers
+	dnsBufLen = 256 // known size for "DNS" values, enough to hold the longest possible hostname or domain name
+
+	DefaultSmallBufLen  = 128  // default size for "typically-small" values with variable sizes: HTTP methods, header names, tls protocol names, cipher suites
+	DefaultMediumBufLen = 1024 // default size for values between small and large with variable sizes
+	DefaultLargeBufLen  = 8192 // default size for "typically-large" values with variable sizes; header values, URLs.
+)
+
 // HTTPVersion describes an HTTP protocol version.
 type HTTPVersion uint32
 
@@ -313,15 +322,6 @@ const (
 	cacheOverrideTagTTL                  cacheOverrideTag = 0b0000_0010 // $ttl
 	cacheOverrideTagStaleWhileRevalidate cacheOverrideTag = 0b0000_0100 // $stale_while_revalidate
 	cacheOverrideTagPCI                  cacheOverrideTag = 0b0000_1000 // $pci
-)
-
-const (
-	ipBufLen  = 16  // known size for IP address buffers
-	dnsBufLen = 256 // known size for "DNS" values, enough to hold the longest possible hostname or domain name
-
-	DefaultSmallBufLen  = 128  // default size for "typically-small" values with variable sizes: HTTP methods, header names, tls protocol names, cipher suites
-	DefaultMediumBufLen = 1024 // default size for values between small and large with variable sizes
-	DefaultLargeBufLen  = 8192 // default size for "typically-large" values with variable sizes; header values, URLs.
 )
 
 // CacheOverrideOptions collects specific, caching-related options for outbound

--- a/internal/abi/prim/prim.go
+++ b/internal/abi/prim/prim.go
@@ -35,7 +35,7 @@ func ToPointer[T any](ptr *T) Pointer[T] {
 
 // NullPointer makes a null pointer to a byte buffer.
 func NullChar8Pointer() Pointer[Char8] {
-        return Pointer[Char8](uintptr(unsafe.Pointer(nil)))
+	return Pointer[Char8](uintptr(unsafe.Pointer(nil)))
 }
 
 // Wstring is a header for a string.
@@ -102,18 +102,18 @@ func (b *WriteBuffer) Len() Usize {
 	return Usize(len(b.buf))
 }
 
-// NPointer returns a pointer to the number of bytes written to th buffer as a
+// NPointer returns a pointer to the number of bytes written to the buffer as a
 // Usize.
 func (b *WriteBuffer) NPointer() *Usize {
 	return &b.n
 }
 
-// NValue returns the number of bytes written to th buffer as a Usize.
+// NValue returns the number of bytes written to the buffer as a Usize.
 func (b *WriteBuffer) NValue() Usize {
 	return b.n
 }
 
-// AsBytes returns a copy of the buffer's data as a byte slice.
+// AsBytes returns a slice of the buffer's data as a byte slice.
 func (b *WriteBuffer) AsBytes() []byte {
 	return b.buf[:b.n]
 }


### PR DESCRIPTION
Closes #101

To enable merging this branch, we verified which of the following hostcalls **fully** support adaptive buffers (return a `buflen` error with a usable value) in both ExecuteD and Viceroy:

ExecuteD:
- [x] fastly_http_req method_get
- [x] fastly_http_req uri_get
- [x] fastly_dictionary get (partial!) _Full support needs new hostcall that returns the needed size_
- [x] fastly_geo lookup
- [x] fastly_secret_store plaintext
- [x] fastly_device_detection lookup
- [x] fastly_cache get_user_metadata
- [x] fastly_http_req downstream_tls_client_hello

Viceroy:
- [x] fastly_device_detection lookup
- [x] fastly_dictionary get (partial!) _Full support needs new hostcall that returns the needed size_
- [x] fastly_http_req method_get
- [x] fastly_http_req uri_get
- [x] fastly_geo lookup
- [x] fastly_secret_store plaintext
- [ ] fastly_cache get_user_metadata (❌ not implemented in viceroy)
- [ ] fastly_http_req downstream_tls_client_hello (❌ not implemented in viceroy)

Any hostcalls found not to match behavior between ExecuteD and Viceroy will be corrected in Viceroy.

Any hostcalls found not to return a useable value in ExecuteD will be held back in a separate branch until a new version is fully rolled to the fleet.