### PR TITLE
fsttest: discard header changes after send

### DIFF
--- a/fsttest/recorder.go
+++ b/fsttest/recorder.go
@@ -32,6 +32,8 @@ func (r *ResponseRecorder) Header() fsthttp.Header {
 	if !r.headersDone {
 		return r.HeaderMap
 	}
+	// Once the send the headers, return a copy so any changes
+	// are discarded.
 	return r.HeaderMap.Clone()
 }
 

--- a/fsttest/recorder.go
+++ b/fsttest/recorder.go
@@ -12,9 +12,10 @@ import (
 // ResponseRecorder is an implementation of fsthttp.ResponseWriter that
 // records its mutations for later inspection in tests.
 type ResponseRecorder struct {
-	Code      int
-	HeaderMap fsthttp.Header
-	Body      *bytes.Buffer
+	Code        int
+	HeaderMap   fsthttp.Header
+	Body        *bytes.Buffer
+	headersDone bool
 }
 
 // NewRecorder returns an initialized ResponseRecorder.
@@ -28,12 +29,18 @@ func NewRecorder() *ResponseRecorder {
 
 // Header returns the response headers to mutate within a handler.
 func (r *ResponseRecorder) Header() fsthttp.Header {
-	return r.HeaderMap
+	if !r.headersDone {
+		return r.HeaderMap
+	}
+	return r.HeaderMap.Clone()
 }
 
 // WriteHeader records the response code.
 func (r *ResponseRecorder) WriteHeader(code int) {
-	r.Code = code
+	if !r.headersDone {
+		r.Code = code
+		r.headersDone = true
+	}
 }
 
 // Write records the response body.  The data is written to the Body

--- a/fsttest/recorder.go
+++ b/fsttest/recorder.go
@@ -15,7 +15,7 @@ type ResponseRecorder struct {
 	Code        int
 	HeaderMap   fsthttp.Header
 	Body        *bytes.Buffer
-	headersDone bool
+	headersSent bool
 }
 
 // NewRecorder returns an initialized ResponseRecorder.
@@ -29,19 +29,18 @@ func NewRecorder() *ResponseRecorder {
 
 // Header returns the response headers to mutate within a handler.
 func (r *ResponseRecorder) Header() fsthttp.Header {
-	if !r.headersDone {
+	if !r.headersSent {
 		return r.HeaderMap
 	}
-	// Once the send the headers, return a copy so any changes
-	// are discarded.
+	// Once sent, return a copy so any changes are discarded.
 	return r.HeaderMap.Clone()
 }
 
 // WriteHeader records the response code.
 func (r *ResponseRecorder) WriteHeader(code int) {
-	if !r.headersDone {
+	if !r.headersSent {
 		r.Code = code
-		r.headersDone = true
+		r.headersSent = true
 	}
 }
 


### PR DESCRIPTION
This should correctly ignore headers set too late to make it into the response.