### PR TITLE
Expose the ability to turn pooling on or off for dynamic backends.

### DIFF
--- a/fsthttp/backend.go
+++ b/fsthttp/backend.go
@@ -300,6 +300,12 @@ func (b *BackendOptions) ClientCertificate(certificate string, key secretstore.S
 	return b
 }
 
+// PoolConnections allows users to turn connection pooling on or off for the
+// backend. Pooling allows the Compute platform to reuse connections across
+// multiple sessions, resulting in lower resource use at the server (because it
+// does not need to reperform the TCP handhsake and TLS authentication when the
+// connection is reused). The default is to pool connections. Set this to false
+// to create a new connection to the backend for every incoming session.
 func (b *BackendOptions) PoolConnections(poolingOn bool) *BackendOptions {
 	b.abiOpts.PoolConnections(poolingOn)
 	return b

--- a/fsthttp/backend.go
+++ b/fsthttp/backend.go
@@ -300,6 +300,11 @@ func (b *BackendOptions) ClientCertificate(certificate string, key secretstore.S
 	return b
 }
 
+func (b *BackendOptions) PoolConnections(poolingOn bool) *BackendOptions {
+	b.abiOpts.PoolConnections(poolingOn)
+	return b
+}
+
 // UseGRPC sets whether or not to connect to the backend via gRPC
 func (b *BackendOptions) UseGRPC(v bool) *BackendOptions {
 	b.abiOpts.UseGRPC(v)

--- a/internal/abi/fastly/types.go
+++ b/internal/abi/fastly/types.go
@@ -884,6 +884,14 @@ func (b *BackendConfigOptions) SNIHostname(sniHostname string) {
 	b.opts.sniHostnameLen = prim.U32(buf.Len())
 }
 
+func (b *BackendConfigOptions) PoolConnections(poolingOn bool) {
+    if poolingOn {
+		b.mask &^= backendConfigOptionsMaskDontPool
+    } else {
+		b.mask |= backendConfigOptionsMaskDontPool
+    }
+}
+
 func (b *BackendConfigOptions) ClientCert(certificate string, key *Secret) {
 	b.mask |= backendConfigOptionsMaskClientCert
 	buf := prim.NewReadBufferFromString(certificate)

--- a/internal/abi/fastly/types.go
+++ b/internal/abi/fastly/types.go
@@ -885,11 +885,11 @@ func (b *BackendConfigOptions) SNIHostname(sniHostname string) {
 }
 
 func (b *BackendConfigOptions) PoolConnections(poolingOn bool) {
-    if poolingOn {
+	if poolingOn {
 		b.mask &^= backendConfigOptionsMaskDontPool
-    } else {
+	} else {
 		b.mask |= backendConfigOptionsMaskDontPool
-    }
+	}
 }
 
 func (b *BackendConfigOptions) ClientCert(certificate string, key *Secret) {


### PR DESCRIPTION
This option looks like it might have been skipped, but can be very handy.