### PR TITLE
fsthttp: SetParseRequestURI now lets you register a url parser

### DIFF
--- a/fsthttp/request.go
+++ b/fsthttp/request.go
@@ -133,6 +133,9 @@ func NewRequest(method string, uri string, body io.Reader) (*Request, error) {
 	}, nil
 }
 
+// _parseRequestURI can be set by SetParseRequestURI
+var _parseRequestURI func(string)(*url.URL, error) = url.ParseRequestURI
+
 func newClientRequest() (*Request, error) {
 	abiReq, abiReqBody, err := fastly.BodyDownstreamGet()
 	if err != nil {
@@ -149,7 +152,7 @@ func newClientRequest() (*Request, error) {
 		return nil, fmt.Errorf("get URI: %w", err)
 	}
 
-	u, err := url.ParseRequestURI(uri)
+	u, err := _parseRequestURI(uri)
 	if err != nil {
 		return nil, fmt.Errorf("parse URI: %w", err)
 	}

--- a/fsthttp/setparseuri.go
+++ b/fsthttp/setparseuri.go
@@ -1,0 +1,14 @@
+//go:build fastlyinternalsetparseuri
+
+package fsthttp
+
+import (
+	"net/url"
+)
+
+// SetParseRequestURI takes a function like url.ParseRequestURI to use when parsing incoming requests
+// It is an experimental interface for applications that want to relax restrictions on url parsing
+// It should generally not be needed, and is likely to change, so please avoid unless absolutely necessary
+func SetParseRequestURI(parseRequestURI func(string)(*url.URL, error)) {
+	_parseRequestURI = parseRequestURI
+}


### PR DESCRIPTION
This is like https://github.com/fastly/compute-sdk-go/pull/136 but more suitable for polite company, with less bloat, less opinion about the right way to parse urls, and near zero overhead unless opted in.

The new entry point is behind its own little build tag, fastlyinternalsetparseuri, because it may be needed at different times than the things behind our other private api build tag.

Tested with a real app.