### PR TITLE
add secretstore.Plaintext convenience function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+
+- secretstore: add Plaintext toplevel convenience function
 
 ## 1.3.3 (2024-09-12)
 

--- a/_examples/secret-store/main.go
+++ b/_examples/secret-store/main.go
@@ -11,28 +11,12 @@ import (
 
 func main() {
 	fsthttp.ServeFunc(func(ctx context.Context, w fsthttp.ResponseWriter, r *fsthttp.Request) {
-		st, err := secretstore.Open("example_secretstore")
+		v, err := secretstore.Plaintext("example_secretstore", "my_secret")
 		switch {
-		case errors.Is(err, secretstore.ErrSecretStoreNotFound):
+		case errors.Is(err, secretstore.ErrSecretStoreNotFound) || errors.Is(err, secretstore.ErrSecretNotFound):
 			fsthttp.Error(w, err.Error(), fsthttp.StatusNotFound)
 			return
 		case err != nil:
-			fsthttp.Error(w, err.Error(), fsthttp.StatusBadGateway)
-			return
-		}
-
-		s, err := st.Get("my_secret")
-		switch {
-		case errors.Is(err, secretstore.ErrSecretNotFound):
-			fsthttp.Error(w, err.Error(), fsthttp.StatusNotFound)
-			return
-		case err != nil:
-			fsthttp.Error(w, err.Error(), fsthttp.StatusBadGateway)
-			return
-		}
-
-		v, err := s.Plaintext()
-		if err != nil {
 			fsthttp.Error(w, err.Error(), fsthttp.StatusBadGateway)
 			return
 		}

--- a/integration_tests/secret_store/main_test.go
+++ b/integration_tests/secret_store/main_test.go
@@ -9,17 +9,7 @@ import (
 )
 
 func TestSecretStore(t *testing.T) {
-	st, err := secretstore.Open("phrases")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	s, err := st.Get("my_phrase")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	v, err := s.Plaintext()
+	v, err := secretstore.Plaintext("phrases", "my_phrase")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/secretstore/secretstore.go
+++ b/secretstore/secretstore.go
@@ -129,3 +129,22 @@ func SecretFromBytes(b []byte) (*Secret, error) {
 
 	return &Secret{s: s}, nil
 }
+
+// Plaintext decrypts and returns the secret value as a byte slice for
+// the given secret store and secret name.
+//
+// This is a convenience function that combines the functionality of
+// [Open], [Store.Get], and [Secret.Plaintext].
+func Plaintext(storeName, secretName string) ([]byte, error) {
+	st, err := Open(storeName)
+	if err != nil {
+		return nil, err
+	}
+
+	s, err := st.Get(secretName)
+	if err != nil {
+		return nil, err
+	}
+
+	return s.Plaintext()
+}


### PR DESCRIPTION
This consolidates opening the store, getting the secret, and decrypting
the secret into a single call, making more a more convenient API for
getting secrets.

Update the integration test and example to use this, since it does
all the same stuff as before.
