### PR TITLE
Retract release v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+## 1.4.1 (2025-04-09)
+
+- packaging: Retract (but do not revert) release 1.4.0 and 1.4.1. Builds will default to using 1.3.3.
 
 ## 1.4.0 (2025-04-07)
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/fastly/compute-sdk-go
 
 go 1.21
+
+retract (
+	v1.4.0 // Observed errors after rollout
+)

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,5 @@ go 1.21
 
 retract (
 	v1.4.0 // Observed errors after rollout
+	v1.4.1 // Contains retractions only
 )


### PR DESCRIPTION
Due to an abundance of caution, as this release has been implicated in a regression, we are retracting it.
We will continue to investigate and update tests to avoid recurrence.

We encourage any customers who deployed using v1.4.0 to revert to the prior release and re-deploy.

If we re-publish these changes, they will be issued a new version number.