### PR TITLE
Reject out-of-order ranges

### DIFF
--- a/cache/core/core.go
+++ b/cache/core/core.go
@@ -211,6 +211,9 @@ func (f *Found) GetRange(from, to uint64) (io.ReadCloser, error) {
 	if to > 0 {
 		bopts.To(to)
 	}
+	if to != 0 && from > to {
+		return nil, fmt.Errorf("GetRange from (%d) > to (%d)", from, to)
+	}
 
 	body, err := f.abiEntry.Body(bopts)
 	if err := ignoreNoneError(err); err != nil {

--- a/cache/core/core_test.go
+++ b/cache/core/core_test.go
@@ -188,13 +188,13 @@ func ExampleFound_GetRange() {
 	}
 
 	// If we try to read an invalid range (from > to), we get an error:
-	body, err := f.GetRange(3, 1)
+	_, err = f.GetRange(3, 1)
 	if err == nil {
 		panic("accepted invalid range")
 	}
 
 	// We can use "0" as a signal value to say "everything to the end":
-	body, err = f.GetRange(3, 0)
+	body, err := f.GetRange(3, 0)
 	if err == nil {
 		panic("accepted invalid range")
 	}

--- a/cache/core/core_test.go
+++ b/cache/core/core_test.go
@@ -3,6 +3,7 @@ package core_test
 import (
 	"fmt"
 	"io"
+	"testing"
 	"time"
 
 	"github.com/fastly/compute-sdk-go/cache/core"
@@ -153,4 +154,58 @@ func ExampleTransaction() {
 		// An unexpected error
 		panic(err)
 	}
+}
+
+func ExampleGetRange() {
+	const (
+		key      = "my_key"
+		contents = "my cached object"
+	)
+
+	// Start by filling the cache...
+	w, err := core.Insert([]byte(key), core.WriteOptions{
+		TTL:           time.Hour,
+		SurrogateKeys: []string{key},
+		Length:        uint64(len(contents)),
+	})
+	if err != nil {
+		panic(err)
+	}
+	if _, err := io.WriteString(w, contents); err != nil {
+		panic(err)
+	}
+	if err := w.Close(); err != nil {
+		panic(err)
+	}
+
+	// We get a response...
+	f, err := core.Lookup([]byte("my_key"), core.LookupOptions{})
+	if err != nil {
+		panic(err)
+	}
+	// ...then discard the body, so we can re-open a new body reading a subset of the bytes.
+	if err := f.Body.Close(); err != nil {
+		panic(err)
+	}
+
+	// If we try to read an invalid range (from > to), we get an error:
+	body, err := f.GetRange(3, 1)
+	if err == nil {
+		panic("accepted invalid range")
+	}
+
+	// We can use "0" as a signal value to say "everything to the end":
+	body, err = f.GetRange(3, 0)
+	if err == nil {
+		panic("accepted invalid range")
+	}
+	cachedStr, err := io.ReadAll(body)
+	if err != nil {
+		panic(err)
+	}
+	if string(cachedStr) != "cached object" {
+		panic(fmt.Sprintf("got: %q, want: %q", cachedStr, "cached object"))
+	}
+
+	fmt.Printf("The cached value was: %s", cachedStr)
 }

--- a/cache/core/core_test.go
+++ b/cache/core/core_test.go
@@ -3,7 +3,6 @@ package core_test
 import (
 	"fmt"
 	"io"
-	"testing"
 	"time"
 
 	"github.com/fastly/compute-sdk-go/cache/core"
@@ -156,7 +155,7 @@ func ExampleTransaction() {
 	}
 }
 
-func ExampleGetRange() {
+func ExampleFound_GetRange() {
 	const (
 		key      = "my_key"
 		contents = "my cached object"


### PR DESCRIPTION
Reject ranges where the start position ("from") comes after the end position ("to").

These don't have a good definition of how they should behave; reject them.
