### PR TITLE
Handle config store values larger than 8k

### DIFF
--- a/internal/abi/fastly/configstore_guest.go
+++ b/internal/abi/fastly/configstore_guest.go
@@ -5,8 +5,6 @@
 package fastly
 
 import (
-	"sync"
-
 	"github.com/fastly/compute-sdk-go/internal/abi/prim"
 )
 
@@ -28,26 +26,14 @@ func fastlyConfigStoreOpen(
 // ConfigStore represents a Fastly config store a collection of read-only
 // key/value pairs. For convenience, keys are modeled as Go strings, and values
 // as byte slices.
-//
-// NOTE: wasm, by definition, is a single-threaded execution environment. This
-// allows us to use valueBuf scratch space between the guest and host to avoid
-// allocations any larger than necessary, without locking.
 type ConfigStore struct {
 	h configstoreHandle
-
-	mu       sync.Mutex // protects valueBuf
-	valueBuf [configstoreMaxValueLen]byte
 }
 
-// Dictionaries are subject to very specific limitations: 255 character keys and 8000 character values, utf-8 encoded.
-// The current storage collation limits utf-8 representations to 3 bytes in length.
+// Config Stores are limited to keys of length 255 character. By default, values are limited to 8000 character values,
+// but this can be adjust on a per-customer basis.
 // https://docs.fastly.com/en/guides/about-edge-dictionaries#limitations-and-considerations
-// https://dev.mysql.com/doc/refman/8.4/en/charset-unicode-utf8mb3.html
-// https://en.wikipedia.org/wiki/UTF-8#Encoding
-const (
-	configstoreMaxKeyLen   = 255 * 3  // known maximum size for config store keys: 755 bytes, for 255 3-byte utf-8 encoded characters
-	configstoreMaxValueLen = 8000 * 3 // known maximum size for config store values: 24,000 bytes, for 8000 3-byte utf-8 encoded characters
-)
+const configstoreMaxKeyLen = 255 * 3 // known maximum size for config store keys: 755 bytes, for 255 3-byte utf-8 encoded characters
 
 // OpenConfigStore returns a reference to the named config store, if it exists.
 func OpenConfigStore(name string) (*ConfigStore, error) {
@@ -85,39 +71,33 @@ func fastlyConfigStoreGet(
 	nWritten prim.Pointer[prim.Usize],
 ) FastlyStatus
 
-// Get the value for key, if it exists. The returned slice's backing array is
-// shared between multiple calls to getBytesUnlocked.
-func (c *ConfigStore) getBytesUnlocked(key string) ([]byte, error) {
+// GetBytes returns a slice of newly-allocated memory for the value
+// corresponding to key.
+func (c *ConfigStore) GetBytes(key string) ([]byte, error) {
 	keyBuffer := prim.NewReadBufferFromString(key)
 	if keyBuffer.Len() > configstoreMaxKeyLen {
 		return nil, FastlyStatusInval.toError()
 	}
-	buf := prim.NewWriteBufferFromBytes(c.valueBuf[:]) // fresh slice of backing array
 	keyStr := keyBuffer.Wstring()
-	status := fastlyConfigStoreGet(
-		c.h,
-		keyStr.Data, keyStr.Len,
-		prim.ToPointer(buf.Char8Pointer()), buf.Cap(),
-		prim.ToPointer(buf.NPointer()),
-	)
-	if err := status.toError(); err != nil {
-		return nil, err
-	}
-	return buf.AsBytes(), nil
-}
 
-// GetBytes returns a slice of newly-allocated memory for the value
-// corresponding to key.
-func (c *ConfigStore) GetBytes(key string) ([]byte, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	v, err := c.getBytesUnlocked(key)
-	if err != nil {
-		return nil, err
+	n := DefaultSmallBufLen
+	for {
+		buf := prim.NewWriteBuffer(n)
+		status := fastlyConfigStoreGet(
+			c.h,
+			keyStr.Data, keyStr.Len,
+			prim.ToPointer(buf.Char8Pointer()), buf.Cap(),
+			prim.ToPointer(buf.NPointer()),
+		)
+		if status == FastlyStatusBufLen && buf.NValue() > 0 {
+			n = int(buf.NValue())
+			continue
+		}
+		if err := status.toError(); err != nil {
+			return nil, err
+		}
+		return buf.AsBytes(), nil
 	}
-	p := make([]byte, len(v))
-	copy(p, v)
-	return p, nil
 }
 
 // Has returns true if key is found.


### PR DESCRIPTION
The maximum allowed length for a config store entry's value is now configurable. The default is still 8k characters, but may be larger. This changes the Config Store implementation to re-size its buffer when encountering a BUFLEN error and try again.