### PR TITLE
expose SendError in the fsthttp package

### DIFF
--- a/fsthttp/senderror.go
+++ b/fsthttp/senderror.go
@@ -1,0 +1,147 @@
+// Copyright 2022 Fastly, Inc.
+
+package fsthttp
+
+import "github.com/fastly/compute-sdk-go/internal/abi/fastly"
+
+// SendError provides detailed information about backend request failures.
+//
+// Use errors.Is() with the sentinel error variables to check for specific error types.
+// Use errors.As() to extract the SendError and access detailed error information if needed.
+//
+// Example usage:
+//
+//	resp, err := req.Send(ctx, "backend")
+//	if err != nil {
+//	    // Check for specific error types using errors.Is()
+//	    if errors.Is(err, fsthttp.ErrConnectionTimeout) {
+//	        log.Println("connection timed out")
+//	        return
+//	    }
+//
+//	    // For DNS errors, extract details using errors.As()
+//	    if errors.Is(err, fsthttp.ErrDNSError) {
+//	        var se fsthttp.SendError
+//	        errors.As(err, &se)
+//	        rcode := se.DNSErrorRCode()
+//	        infoCode := se.DNSErrorInfoCode()
+//	        log.Printf("DNS lookup failed: rcode=%d, info=%d", rcode, infoCode)
+//	        return
+//	    }
+//
+//	    // For TLS alert errors, extract alert details
+//	    if errors.Is(err, fsthttp.ErrTLSAlertReceived) {
+//	        var se fsthttp.SendError
+//	        errors.As(err, &se)
+//	        log.Printf("TLS alert: %s (id=%d)", se.TLSAlertDescription(), se.TLSAlertID())
+//	        return
+//	    }
+//	}
+type SendError = fastly.SendErrorDetail
+
+// Sentinel errors for backend request failures.
+// Use these with errors.Is() to check for specific error types.
+var (
+	// ErrDNSTimeout indicates the system encountered a timeout when trying to
+	// find an IP address for the backend hostname.
+	ErrDNSTimeout = fastly.SendErrorDNSTimeout
+
+	// ErrDNSError indicates the system encountered a DNS error when trying to
+	// find an IP address for the backend hostname.
+	// Use DNSErrorRCode() and DNSErrorInfoCode() to get additional details.
+	ErrDNSError = fastly.SendErrorDNSError
+
+	// ErrDestinationNotFound indicates the system cannot determine which backend
+	// to use, or the specified backend was invalid.
+	ErrDestinationNotFound = fastly.SendErrorDestinationNotFound
+
+	// ErrDestinationUnavailable indicates the system considers the backend to be
+	// unavailable (e.g., recent attempts to communicate with it may have failed,
+	// or a health check may indicate that it is down).
+	ErrDestinationUnavailable = fastly.SendErrorDestinationUnavailable
+
+	// ErrDestinationIPUnroutable indicates the system cannot find a route to the
+	// next-hop IP address.
+	ErrDestinationIPUnroutable = fastly.SendErrorDestinationIPUnroutable
+
+	// ErrConnectionRefused indicates the system's connection to the backend was
+	// refused.
+	ErrConnectionRefused = fastly.SendErrorConnectionRefused
+
+	// ErrConnectionTerminated indicates the system's connection to the backend
+	// was closed before a complete response was received.
+	ErrConnectionTerminated = fastly.SendErrorConnectionTerminated
+
+	// ErrConnectionTimeout indicates the system's attempt to open a connection
+	// to the backend timed out.
+	ErrConnectionTimeout = fastly.SendErrorConnectionTimeout
+
+	// ErrConnectionLimitReached indicates the system is configured to limit the
+	// number of connections it has to the backend, and that limit has been
+	// reached.
+	ErrConnectionLimitReached = fastly.SendErrorConnectionLimitReached
+
+	// ErrTLSCertificateError indicates the system encountered an error when
+	// verifying the certificate presented by the backend.
+	ErrTLSCertificateError = fastly.SendErrorTLSCertificateError
+
+	// ErrTLSConfigurationError indicates the system encountered an error with
+	// the backend TLS configuration.
+	ErrTLSConfigurationError = fastly.SendErrorTLSConfigurationError
+
+	// ErrTLSAlertReceived indicates the system received a TLS alert from the
+	// backend. Use TLSAlertID() and TLSAlertDescription() to get the specific alert.
+	ErrTLSAlertReceived = fastly.SendErrorTLSAlertReceived
+
+	// ErrTLSProtocolError indicates the system encountered a TLS error when
+	// communicating with the backend, either during the handshake or afterwards.
+	ErrTLSProtocolError = fastly.SendErrorTLSProtocolError
+
+	// ErrHTTPIncompleteResponse indicates the system received an incomplete
+	// response to the request from the backend.
+	ErrHTTPIncompleteResponse = fastly.SendErrorHTTPIncompleteResponse
+
+	// ErrHTTPResponseHeaderSectionTooLarge indicates the system received a
+	// response to the request whose header section was considered too large.
+	// For specific limits, visit the [Compute resource limits documentation].
+	//
+	// [Compute resource limits documentation]: https://docs.fastly.com/products/compute-resource-limits
+	ErrHTTPResponseHeaderSectionTooLarge = fastly.SendErrorHTTPResponseHeaderSectionTooLarge
+
+	// ErrHTTPResponseBodyTooLarge indicates the system received a response to
+	// the request whose body was considered too large.
+	// For specific limits, visit the [Compute resource limits documentation].
+	//
+	// [Compute resource limits documentation]: https://docs.fastly.com/products/compute-resource-limits
+	ErrHTTPResponseBodyTooLarge = fastly.SendErrorHTTPResponseBodyTooLarge
+
+	// ErrHTTPResponseTimeout indicates the system reached a configured time
+	// limit waiting for the complete response.  The limit is configured on the
+	// backend.
+	ErrHTTPResponseTimeout = fastly.SendErrorHTTPResponseTimeout
+
+	// ErrHTTPResponseStatusInvalid indicates the system received a response to
+	// the request whose status code or reason phrase was invalid.
+	ErrHTTPResponseStatusInvalid = fastly.SendErrorHTTPResponseStatusInvalid
+
+	// ErrHTTPUpgradeFailed indicates the process of negotiating an upgrade of
+	// the HTTP version between the system and the backend failed.
+	ErrHTTPUpgradeFailed = fastly.SendErrorHTTPUpgradeFailed
+
+	// ErrHTTPProtocolError indicates the system encountered an HTTP protocol
+	// error when communicating with the backend. This error will only be used
+	// when a more specific one is not defined.
+	ErrHTTPProtocolError = fastly.SendErrorHTTPProtocolError
+
+	// ErrHTTPRequestCacheKeyInvalid indicates an invalid Fastly cache key was provided
+	// for the request.
+	ErrHTTPRequestCacheKeyInvalid = fastly.SendErrorHTTPRequestCacheKeyInvalid
+
+	// ErrHTTPRequestURIInvalid indicates an invalid URI was provided for the
+	// request.
+	ErrHTTPRequestURIInvalid = fastly.SendErrorHTTPRequestURIInvalid
+
+	// ErrInternalError indicates the system encountered an unexpected internal
+	// error.
+	ErrInternalError = fastly.SendErrorInternalError
+)

--- a/fsthttp/senderror_test.go
+++ b/fsthttp/senderror_test.go
@@ -1,0 +1,82 @@
+// Copyright 2022 Fastly, Inc.
+
+package fsthttp
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/fastly/compute-sdk-go/internal/abi/fastly"
+)
+
+func TestSendErrorIs(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		target   error
+		expected bool
+	}{
+		{
+			name:     "connection timeout matches",
+			err:      ErrConnectionTimeout,
+			target:   ErrConnectionTimeout,
+			expected: true,
+		},
+		{
+			name:     "different errors don't match",
+			err:      ErrConnectionTimeout,
+			target:   ErrDNSTimeout,
+			expected: false,
+		},
+		{
+			name:     "wrapped error matches",
+			err:      fmt.Errorf("send failed: %w", ErrConnectionTimeout),
+			target:   ErrConnectionTimeout,
+			expected: true,
+		},
+		{
+			name:     "FastlyError with SendErrorDetail matches",
+			err:      fastly.FastlyError{Status: fastly.FastlyStatusError, Detail: fastly.SendErrorConnectionTimeout},
+			target:   ErrConnectionTimeout,
+			expected: true,
+		},
+		{
+			name:     "doubly wrapped error matches",
+			err:      fmt.Errorf("request failed: %w", fmt.Errorf("backend error: %w", ErrDNSError)),
+			target:   ErrDNSError,
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := errors.Is(tt.err, tt.target)
+			if result != tt.expected {
+				t.Errorf("errors.Is() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSendErrorAs(t *testing.T) {
+	dnsErr := fastly.SendErrorDNSError
+
+	wrappedErr := fastly.FastlyError{
+		Status: fastly.FastlyStatusError,
+		Detail: dnsErr,
+	}
+
+	wrappedAgainErr := fmt.Errorf("request failed: %w", wrappedErr)
+
+	// Test that we can extract it with errors.As()
+	var se SendError
+	if !errors.As(wrappedAgainErr, &se) {
+		t.Fatal("errors.As() failed to extract SendError")
+	}
+
+	// Verify it matches the expected error
+	if !errors.Is(se, ErrDNSError) {
+		t.Error("extracted SendError does not match ErrDNSError")
+	}
+}

--- a/internal/abi/fastly/http_guest.go
+++ b/internal/abi/fastly/http_guest.go
@@ -666,7 +666,7 @@ func fastlyHTTPReqSendV2(
 	h requestHandle,
 	b bodyHandle,
 	backendData prim.Pointer[prim.U8], backendLen prim.Usize,
-	errDetail prim.Pointer[sendErrorDetail],
+	errDetail prim.Pointer[SendErrorDetail],
 	resp prim.Pointer[responseHandle],
 	respBody prim.Pointer[bodyHandle],
 ) FastlyStatus
@@ -725,7 +725,7 @@ func fastlyHTTPReqSendV3(
 	h requestHandle,
 	b bodyHandle,
 	backendData prim.Pointer[prim.U8], backendLen prim.Usize,
-	errDetail prim.Pointer[sendErrorDetail],
+	errDetail prim.Pointer[SendErrorDetail],
 	resp prim.Pointer[responseHandle],
 	respBody prim.Pointer[bodyHandle],
 ) FastlyStatus
@@ -785,7 +785,7 @@ type PendingRequest struct {
 // The body is buffered and sent all at once. Returns immediately with a
 // reference to the newly created request.
 func (r *HTTPRequest) SendAsync(requestBody *HTTPBody, backend string) (*PendingRequest, error) {
-	var pendingHandle = invalidPendingRequestHandle
+	pendingHandle := invalidPendingRequestHandle
 
 	backendBuffer := prim.NewReadBufferFromString(backend).Wstring()
 
@@ -838,7 +838,7 @@ func fastlyHTTPReqSendAsyncV2(
 // The body is buffered and sent all at once. Returns immediately with a
 // reference to the newly created request.  Does not set `X-Cache` or similar.
 func (r *HTTPRequest) SendAsyncV2(requestBody *HTTPBody, backend string, streaming bool) (*PendingRequest, error) {
-	var pendingHandle = invalidPendingRequestHandle
+	pendingHandle := invalidPendingRequestHandle
 
 	backendBuffer := prim.NewReadBufferFromString(backend).Wstring()
 
@@ -884,7 +884,7 @@ func fastlyHTTPReqSendAsyncStreaming(
 // buffered and sent all at once. Returns immediately with a reference to the
 // newly created request.
 func (r *HTTPRequest) SendAsyncStreaming(requestBody *HTTPBody, backend string) (*PendingRequest, error) {
-	var pendingHandle = invalidPendingRequestHandle
+	pendingHandle := invalidPendingRequestHandle
 
 	backendBuffer := prim.NewReadBufferFromString(backend).Wstring()
 
@@ -918,7 +918,7 @@ func (r *HTTPRequest) SendAsyncStreaming(requestBody *HTTPBody, backend string) 
 //go:noescape
 func fastlyHTTPReqPendingReqPollV2(
 	h pendingRequestHandle,
-	errDetail prim.Pointer[sendErrorDetail],
+	errDetail prim.Pointer[SendErrorDetail],
 	isDone prim.Pointer[prim.U32],
 	resp prim.Pointer[responseHandle],
 	respBody prim.Pointer[bodyHandle],
@@ -962,7 +962,7 @@ func (r *PendingRequest) Poll() (done bool, response *HTTPResponse, responseBody
 //go:noescape
 func fastlyHTTPReqPendingReqWaitV2(
 	h pendingRequestHandle,
-	errDetail prim.Pointer[sendErrorDetail],
+	errDetail prim.Pointer[SendErrorDetail],
 	resp prim.Pointer[responseHandle],
 	respBody prim.Pointer[bodyHandle],
 ) FastlyStatus
@@ -1078,9 +1078,7 @@ func fastlyHTTPDownstreamNextRequest(
 ) FastlyStatus
 
 func DownstreamNextRequest(opts *NextRequestOptions) (*HTTPRequestPromise, error) {
-	var (
-		rh requestPromiseHandle = invalidRequestPromiseHandle
-	)
+	rh := invalidRequestPromiseHandle
 
 	if err := fastlyHTTPDownstreamNextRequest(
 		opts.mask,
@@ -1793,7 +1791,7 @@ func fastlyHTTPBodyNew(
 
 // NewHTTPBody returns a new, empty HTTP body.
 func NewHTTPBody() (*HTTPBody, error) {
-	var b = invalidBodyHandle
+	b := invalidBodyHandle
 
 	if err := fastlyHTTPBodyNew(
 		prim.ToPointer(&b),
@@ -1973,7 +1971,6 @@ func fastlyHTTPBodyKnownLength(
 // The length of the cached item may be unknown if the item is currently being streamed into
 // the cache without a fixed length.
 func (b *HTTPBody) Length() (uint64, error) {
-
 	var l prim.U64
 
 	if err := fastlyHTTPBodyKnownLength(
@@ -2008,7 +2005,7 @@ type HTTPResponse struct {
 
 // NewHTTPREsponse returns a valid, empty HTTP response.
 func NewHTTPResponse() (*HTTPResponse, error) {
-	var respHandle = invalidResponseHandle
+	respHandle := invalidResponseHandle
 
 	if err := fastlyHTTPRespNew(
 		prim.ToPointer(&respHandle),
@@ -2054,7 +2051,6 @@ func (r *HTTPResponse) GetHeaderNames() *Values {
 		endingCursorOut *multiValueCursorResult,
 		nwrittenOut *prim.Usize,
 	) FastlyStatus {
-
 		return fastlyHTTPRespHeaderNamesGet(
 			r.h,
 			prim.ToPointer(buf),
@@ -2331,7 +2327,6 @@ func fastlyHTTPRespVersionSet(
 
 // SetVersion sets the HTTP version of the response.
 func (r *HTTPResponse) SetVersion(v HTTPVersion) error {
-
 	return fastlyHTTPRespVersionSet(
 		r.h,
 		v,


### PR DESCRIPTION
req.Send() can return a SendError which provides detailed information
about backend request failures.  This was previously only provided to
user code as a string, but this change exposes it as a proper type.

Users can use errors.Is() with sentinel error variables to check
for specific error types, and use errors.As() to extract the SendError
and access detailed error information if needed.

Fixes #191
