### PR TITLE
rework SendError to have Cause() rather than Is()

### DIFF
--- a/fsthttp/senderror.go
+++ b/fsthttp/senderror.go
@@ -6,142 +6,128 @@ import "github.com/fastly/compute-sdk-go/internal/abi/fastly"
 
 // SendError provides detailed information about backend request failures.
 //
-// Use errors.Is() with the sentinel error variables to check for specific error values.
-// Use errors.As() to extract the SendError and access detailed error information if needed.
+// Use errors.As() to extract the SendError from the error chain, then use the
+// Cause() method to determine the specific error cause.
 //
 // Example usage:
 //
 //	resp, err := req.Send(ctx, "backend")
 //	if err != nil {
-//	    // Check for specific error values using errors.Is()
-//	    if errors.Is(err, fsthttp.ErrConnectionTimeout) {
-//	        log.Println("connection timed out")
-//	        return
-//	    }
+//	    var se fsthttp.SendError
+//	    if errors.As(err, &se) {
+//	        switch se.Cause() {
+//	        case fsthttp.SendErrorConnectionTimeout:
+//	            log.Println("connection timed out")
 //
-//	    // For DNS errors, extract details using errors.As()
-//	    if errors.Is(err, fsthttp.ErrDNSError) {
-//	        var se fsthttp.SendError
-//	        errors.As(err, &se)
-//	        rcode := se.DNSErrorRCode()
-//	        infoCode := se.DNSErrorInfoCode()
-//	        log.Printf("DNS lookup failed: rcode=%d, info=%d", rcode, infoCode)
-//	        return
-//	    }
+//	        case fsthttp.SendErrorDNSError:
+//	            log.Printf("DNS lookup failed: rcode=%d, info=%d", se.DNSErrorRCode(), se.DNSErrorInfoCode())
 //
-//	    // For TLS alert errors, extract alert details
-//	    if errors.Is(err, fsthttp.ErrTLSAlertReceived) {
-//	        var se fsthttp.SendError
-//	        errors.As(err, &se)
-//	        log.Printf("TLS alert: %s (id=%d)", se.TLSAlertDescription(), se.TLSAlertID())
-//	        return
+//	        case fsthttp.SendErrorTLSAlertReceived:
+//	            log.Printf("TLS alert: %d (%s)", se.TLSAlertID(), se.TLSAlertDescription())
+//	        }
 //	    }
 //	}
 type SendError = fastly.SendErrorDetail
 
-// Sentinel errors for backend request failures.
-// Use these with errors.Is() to check for specific error values.
-var (
-	// ErrDNSTimeout indicates the system encountered a timeout when trying to
+const (
+	// SendErrorDNSTimeout indicates the system encountered a timeout when trying to
 	// find an IP address for the backend hostname.
-	ErrDNSTimeout = fastly.SendErrorDNSTimeout
+	SendErrorDNSTimeout = fastly.SendErrorDetailTagDNSTimeout
 
-	// ErrDNSError indicates the system encountered a DNS error when trying to
+	// SendErrorDNSError indicates the system encountered a DNS error when trying to
 	// find an IP address for the backend hostname.
 	// Use DNSErrorRCode() and DNSErrorInfoCode() to get additional details.
-	ErrDNSError = fastly.SendErrorDNSError
+	SendErrorDNSError = fastly.SendErrorDetailTagDNSError
 
-	// ErrDestinationNotFound indicates the system cannot determine which backend
+	// SendErrorDestinationNotFound indicates the system cannot determine which backend
 	// to use, or the specified backend was invalid.
-	ErrDestinationNotFound = fastly.SendErrorDestinationNotFound
+	SendErrorDestinationNotFound = fastly.SendErrorDetailTagDestinationNotFound
 
-	// ErrDestinationUnavailable indicates the system considers the backend to be
+	// SendErrorDestinationUnavailable indicates the system considers the backend to be
 	// unavailable (e.g., recent attempts to communicate with it may have failed,
 	// or a health check may indicate that it is down).
-	ErrDestinationUnavailable = fastly.SendErrorDestinationUnavailable
+	SendErrorDestinationUnavailable = fastly.SendErrorDetailTagDestinationUnavailable
 
-	// ErrDestinationIPUnroutable indicates the system cannot find a route to the
+	// SendErrorDestinationIPUnroutable indicates the system cannot find a route to the
 	// next-hop IP address.
-	ErrDestinationIPUnroutable = fastly.SendErrorDestinationIPUnroutable
+	SendErrorDestinationIPUnroutable = fastly.SendErrorDetailTagDestinationIPUnroutable
 
-	// ErrConnectionRefused indicates the system's connection to the backend was
+	// SendErrorConnectionRefused indicates the system's connection to the backend was
 	// refused.
-	ErrConnectionRefused = fastly.SendErrorConnectionRefused
+	SendErrorConnectionRefused = fastly.SendErrorDetailTagConnectionRefused
 
-	// ErrConnectionTerminated indicates the system's connection to the backend
+	// SendErrorConnectionTerminated indicates the system's connection to the backend
 	// was closed before a complete response was received.
-	ErrConnectionTerminated = fastly.SendErrorConnectionTerminated
+	SendErrorConnectionTerminated = fastly.SendErrorDetailTagConnectionTerminated
 
-	// ErrConnectionTimeout indicates the system's attempt to open a connection
+	// SendErrorConnectionTimeout indicates the system's attempt to open a connection
 	// to the backend timed out.
-	ErrConnectionTimeout = fastly.SendErrorConnectionTimeout
+	SendErrorConnectionTimeout = fastly.SendErrorDetailTagConnectionTimeout
 
-	// ErrConnectionLimitReached indicates the system is configured to limit the
-	// number of connections it has to the backend, and that limit has been
-	// reached.
-	ErrConnectionLimitReached = fastly.SendErrorConnectionLimitReached
+	// SendErrorConnectionLimitReached indicates the system is configured to limit the
+	// number of connections it has to the backend, and that limit has been reached.
+	SendErrorConnectionLimitReached = fastly.SendErrorDetailTagConnectionLimitReached
 
-	// ErrTLSCertificateError indicates the system encountered an error when
+	// SendErrorTLSCertificateError indicates the system encountered an error when
 	// verifying the certificate presented by the backend.
-	ErrTLSCertificateError = fastly.SendErrorTLSCertificateError
+	SendErrorTLSCertificateError = fastly.SendErrorDetailTagTLSCertificateError
 
-	// ErrTLSConfigurationError indicates the system encountered an error with
+	// SendErrorTLSConfigurationError indicates the system encountered an error with
 	// the backend TLS configuration.
-	ErrTLSConfigurationError = fastly.SendErrorTLSConfigurationError
+	SendErrorTLSConfigurationError = fastly.SendErrorDetailTagTLSConfigurationError
 
-	// ErrTLSAlertReceived indicates the system received a TLS alert from the
+	// SendErrorTLSAlertReceived indicates the system received a TLS alert from the
 	// backend. Use TLSAlertID() and TLSAlertDescription() to get the specific alert.
-	ErrTLSAlertReceived = fastly.SendErrorTLSAlertReceived
+	SendErrorTLSAlertReceived = fastly.SendErrorDetailTagTLSAlertReceived
 
-	// ErrTLSProtocolError indicates the system encountered a TLS error when
+	// SendErrorTLSProtocolError indicates the system encountered a TLS error when
 	// communicating with the backend, either during the handshake or afterwards.
-	ErrTLSProtocolError = fastly.SendErrorTLSProtocolError
+	SendErrorTLSProtocolError = fastly.SendErrorDetailTagTLSProtocolError
 
-	// ErrHTTPIncompleteResponse indicates the system received an incomplete
+	// SendErrorHTTPIncompleteResponse indicates the system received an incomplete
 	// response to the request from the backend.
-	ErrHTTPIncompleteResponse = fastly.SendErrorHTTPIncompleteResponse
+	SendErrorHTTPIncompleteResponse = fastly.SendErrorDetailTagHTTPIncompleteResponse
 
-	// ErrHTTPResponseHeaderSectionTooLarge indicates the system received a
+	// SendErrorHTTPResponseHeaderSectionTooLarge indicates the system received a
 	// response to the request whose header section was considered too large.
 	// For specific limits, visit the [Compute resource limits documentation].
 	//
 	// [Compute resource limits documentation]: https://docs.fastly.com/products/compute-resource-limits
-	ErrHTTPResponseHeaderSectionTooLarge = fastly.SendErrorHTTPResponseHeaderSectionTooLarge
+	SendErrorHTTPResponseHeaderSectionTooLarge = fastly.SendErrorDetailTagHTTPResponseHeaderSectionTooLarge
 
-	// ErrHTTPResponseBodyTooLarge indicates the system received a response to
+	// SendErrorHTTPResponseBodyTooLarge indicates the system received a response to
 	// the request whose body was considered too large.
 	// For specific limits, visit the [Compute resource limits documentation].
 	//
 	// [Compute resource limits documentation]: https://docs.fastly.com/products/compute-resource-limits
-	ErrHTTPResponseBodyTooLarge = fastly.SendErrorHTTPResponseBodyTooLarge
+	SendErrorHTTPResponseBodyTooLarge = fastly.SendErrorDetailTagHTTPResponseBodyTooLarge
 
-	// ErrHTTPResponseTimeout indicates the system reached a configured time
-	// limit waiting for the complete response.  The limit is configured on the
-	// backend.
-	ErrHTTPResponseTimeout = fastly.SendErrorHTTPResponseTimeout
+	// SendErrorHTTPResponseTimeout indicates the system reached a configured time
+	// limit waiting for the complete response.  The limit is configured on the backend.
+	SendErrorHTTPResponseTimeout = fastly.SendErrorDetailTagHTTPResponseTimeout
 
-	// ErrHTTPResponseStatusInvalid indicates the system received a response to
+	// SendErrorHTTPResponseStatusInvalid indicates the system received a response to
 	// the request whose status code or reason phrase was invalid.
-	ErrHTTPResponseStatusInvalid = fastly.SendErrorHTTPResponseStatusInvalid
+	SendErrorHTTPResponseStatusInvalid = fastly.SendErrorDetailTagHTTPResponseStatusInvalid
 
-	// ErrHTTPUpgradeFailed indicates the process of negotiating an upgrade of
+	// SendErrorHTTPUpgradeFailed indicates the process of negotiating an upgrade of
 	// the HTTP version between the system and the backend failed.
-	ErrHTTPUpgradeFailed = fastly.SendErrorHTTPUpgradeFailed
+	SendErrorHTTPUpgradeFailed = fastly.SendErrorDetailTagHTTPUpgradeFailed
 
-	// ErrHTTPProtocolError indicates the system encountered an HTTP protocol
-	// error when communicating with the backend. This error will only be used
-	// when a more specific one is not defined.
-	ErrHTTPProtocolError = fastly.SendErrorHTTPProtocolError
+	// SendErrorHTTPProtocolError indicates the system encountered an HTTP protocol
+	// error when communicating with the backend. This error will only be used when a more
+	// specific one is not defined.
+	SendErrorHTTPProtocolError = fastly.SendErrorDetailTagHTTPProtocolError
 
-	// ErrHTTPRequestCacheKeyInvalid indicates an invalid Fastly cache key was provided
-	// for the request.
-	ErrHTTPRequestCacheKeyInvalid = fastly.SendErrorHTTPRequestCacheKeyInvalid
+	// SendErrorHTTPRequestCacheKeyInvalid indicates an invalid Fastly cache key was
+	// provided for the request.
+	SendErrorHTTPRequestCacheKeyInvalid = fastly.SendErrorDetailTagHTTPRequestCacheKeyInvalid
 
-	// ErrHTTPRequestURIInvalid indicates an invalid URI was provided for the
+	// SendErrorHTTPRequestURIInvalid indicates an invalid URI was provided for the
 	// request.
-	ErrHTTPRequestURIInvalid = fastly.SendErrorHTTPRequestURIInvalid
+	SendErrorHTTPRequestURIInvalid = fastly.SendErrorDetailTagHTTPRequestURIInvalid
 
-	// ErrInternalError indicates the system encountered an unexpected internal
+	// SendErrorInternalError indicates the system encountered an unexpected internal
 	// error.
-	ErrInternalError = fastly.SendErrorInternalError
+	SendErrorInternalError = fastly.SendErrorDetailTagInternalError
 )

--- a/fsthttp/senderror_test.go
+++ b/fsthttp/senderror_test.go
@@ -10,73 +10,24 @@ import (
 	"github.com/fastly/compute-sdk-go/internal/abi/fastly"
 )
 
-func TestSendErrorIs(t *testing.T) {
-	tests := []struct {
-		name     string
-		err      error
-		target   error
-		expected bool
-	}{
-		{
-			name:     "connection timeout matches",
-			err:      ErrConnectionTimeout,
-			target:   ErrConnectionTimeout,
-			expected: true,
-		},
-		{
-			name:     "different errors don't match",
-			err:      ErrConnectionTimeout,
-			target:   ErrDNSTimeout,
-			expected: false,
-		},
-		{
-			name:     "wrapped error matches",
-			err:      fmt.Errorf("send failed: %w", ErrConnectionTimeout),
-			target:   ErrConnectionTimeout,
-			expected: true,
-		},
-		{
-			name:     "FastlyError with SendErrorDetail matches",
-			err:      fastly.FastlyError{Status: fastly.FastlyStatusError, Detail: fastly.SendErrorConnectionTimeout},
-			target:   ErrConnectionTimeout,
-			expected: true,
-		},
-		{
-			name:     "doubly wrapped error matches",
-			err:      fmt.Errorf("request failed: %w", fmt.Errorf("backend error: %w", ErrDNSError)),
-			target:   ErrDNSError,
-			expected: true,
-		},
+func TestSendErrorWrapped(t *testing.T) {
+	detail := SendError{
+		Tag: SendErrorConnectionTimeout,
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := errors.Is(tt.err, tt.target)
-			if result != tt.expected {
-				t.Errorf("errors.Is() = %v, want %v", result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestSendErrorAs(t *testing.T) {
-	dnsErr := fastly.SendErrorDNSError
 
 	wrappedErr := fastly.FastlyError{
 		Status: fastly.FastlyStatusError,
-		Detail: dnsErr,
+		Detail: detail,
 	}
 
 	wrappedAgainErr := fmt.Errorf("request failed: %w", wrappedErr)
 
-	// Test that we can extract it with errors.As()
-	var se SendError
-	if !errors.As(wrappedAgainErr, &se) {
+	var serr SendError
+	if !errors.As(wrappedAgainErr, &serr) {
 		t.Fatal("errors.As() failed to extract SendError")
 	}
 
-	// Verify it matches the expected error
-	if !errors.Is(se, ErrDNSError) {
-		t.Error("extracted SendError does not match ErrDNSError")
+	if serr.Cause() != SendErrorConnectionTimeout {
+		t.Errorf("Cause() = %v, want %v", serr.Cause(), SendErrorConnectionTimeout)
 	}
 }

--- a/internal/abi/fastly/types.go
+++ b/internal/abi/fastly/types.go
@@ -1242,34 +1242,34 @@ func (b *BackendConfigOptions) TCPKeepaliveTime(t time.Duration) {
 //	        ;;; the handshake or afterwards.
 //	        $tls_protocol_error
 //	        ))
-type sendErrorDetailTag prim.U32
+type SendErrorDetailTag prim.U32
 
 const (
-	sendErrorDetailTagUninitialized                     sendErrorDetailTag = 0
-	sendErrorDetailTagOK                                sendErrorDetailTag = 1
-	sendErrorDetailTagDNSTimeout                        sendErrorDetailTag = 2
-	sendErrorDetailTagDNSError                          sendErrorDetailTag = 3
-	sendErrorDetailTagDestinationNotFound               sendErrorDetailTag = 4
-	sendErrorDetailTagDestinationUnavailable            sendErrorDetailTag = 5
-	sendErrorDetailTagDestinationIPUnroutable           sendErrorDetailTag = 6
-	sendErrorDetailTagConnectionRefused                 sendErrorDetailTag = 7
-	sendErrorDetailTagConnectionTerminated              sendErrorDetailTag = 8
-	sendErrorDetailTagConnectionTimeout                 sendErrorDetailTag = 9
-	sendErrorDetailTagConnectionLimitReached            sendErrorDetailTag = 10
-	sendErrorDetailTagTLSCertificateError               sendErrorDetailTag = 11
-	sendErrorDetailTagTLSConfigurationError             sendErrorDetailTag = 12
-	sendErrorDetailTagHTTPIncompleteResponse            sendErrorDetailTag = 13
-	sendErrorDetailTagHTTPResponseHeaderSectionTooLarge sendErrorDetailTag = 14
-	sendErrorDetailTagHTTPResponseBodyTooLarge          sendErrorDetailTag = 15
-	sendErrorDetailTagHTTPResponseTimeout               sendErrorDetailTag = 16
-	sendErrorDetailTagHTTPResponseStatusInvalid         sendErrorDetailTag = 17
-	sendErrorDetailTagHTTPUpgradeFailed                 sendErrorDetailTag = 18
-	sendErrorDetailTagHTTPProtocolError                 sendErrorDetailTag = 19
-	sendErrorDetailTagHTTPRequestCacheKeyInvalid        sendErrorDetailTag = 20
-	sendErrorDetailTagHTTPRequestURIInvalid             sendErrorDetailTag = 21
-	sendErrorDetailTagInternalError                     sendErrorDetailTag = 22
-	sendErrorDetailTagTLSAlertReceived                  sendErrorDetailTag = 23
-	sendErrorDetailTagTLSProtocolError                  sendErrorDetailTag = 24
+	SendErrorDetailTagUninitialized                     SendErrorDetailTag = 0
+	SendErrorDetailTagOK                                SendErrorDetailTag = 1
+	SendErrorDetailTagDNSTimeout                        SendErrorDetailTag = 2
+	SendErrorDetailTagDNSError                          SendErrorDetailTag = 3
+	SendErrorDetailTagDestinationNotFound               SendErrorDetailTag = 4
+	SendErrorDetailTagDestinationUnavailable            SendErrorDetailTag = 5
+	SendErrorDetailTagDestinationIPUnroutable           SendErrorDetailTag = 6
+	SendErrorDetailTagConnectionRefused                 SendErrorDetailTag = 7
+	SendErrorDetailTagConnectionTerminated              SendErrorDetailTag = 8
+	SendErrorDetailTagConnectionTimeout                 SendErrorDetailTag = 9
+	SendErrorDetailTagConnectionLimitReached            SendErrorDetailTag = 10
+	SendErrorDetailTagTLSCertificateError               SendErrorDetailTag = 11
+	SendErrorDetailTagTLSConfigurationError             SendErrorDetailTag = 12
+	SendErrorDetailTagHTTPIncompleteResponse            SendErrorDetailTag = 13
+	SendErrorDetailTagHTTPResponseHeaderSectionTooLarge SendErrorDetailTag = 14
+	SendErrorDetailTagHTTPResponseBodyTooLarge          SendErrorDetailTag = 15
+	SendErrorDetailTagHTTPResponseTimeout               SendErrorDetailTag = 16
+	SendErrorDetailTagHTTPResponseStatusInvalid         SendErrorDetailTag = 17
+	SendErrorDetailTagHTTPUpgradeFailed                 SendErrorDetailTag = 18
+	SendErrorDetailTagHTTPProtocolError                 SendErrorDetailTag = 19
+	SendErrorDetailTagHTTPRequestCacheKeyInvalid        SendErrorDetailTag = 20
+	SendErrorDetailTagHTTPRequestURIInvalid             SendErrorDetailTag = 21
+	SendErrorDetailTagInternalError                     SendErrorDetailTag = 22
+	SendErrorDetailTagTLSAlertReceived                  SendErrorDetailTag = 23
+	SendErrorDetailTagTLSProtocolError                  SendErrorDetailTag = 24
 )
 
 // witx:
@@ -1308,7 +1308,7 @@ const (
 
 // SendErrorDetail contains detailed error information from backend send operations.
 type SendErrorDetail struct {
-	tag              sendErrorDetailTag
+	Tag              SendErrorDetailTag
 	mask             sendErrorDetailMask
 	dnsErrorRCode    prim.U16
 	dnsErrorInfoCode prim.U16
@@ -1321,56 +1321,25 @@ func newSendErrorDetail() SendErrorDetail {
 	}
 }
 
-// Sentinel send errors for use with errors.Is().
-var (
-	SendErrorDNSTimeout                        = SendErrorDetail{tag: sendErrorDetailTagDNSTimeout}
-	SendErrorDNSError                          = SendErrorDetail{tag: sendErrorDetailTagDNSError}
-	SendErrorDestinationNotFound               = SendErrorDetail{tag: sendErrorDetailTagDestinationNotFound}
-	SendErrorDestinationUnavailable            = SendErrorDetail{tag: sendErrorDetailTagDestinationUnavailable}
-	SendErrorDestinationIPUnroutable           = SendErrorDetail{tag: sendErrorDetailTagDestinationIPUnroutable}
-	SendErrorConnectionRefused                 = SendErrorDetail{tag: sendErrorDetailTagConnectionRefused}
-	SendErrorConnectionTerminated              = SendErrorDetail{tag: sendErrorDetailTagConnectionTerminated}
-	SendErrorConnectionTimeout                 = SendErrorDetail{tag: sendErrorDetailTagConnectionTimeout}
-	SendErrorConnectionLimitReached            = SendErrorDetail{tag: sendErrorDetailTagConnectionLimitReached}
-	SendErrorTLSCertificateError               = SendErrorDetail{tag: sendErrorDetailTagTLSCertificateError}
-	SendErrorTLSConfigurationError             = SendErrorDetail{tag: sendErrorDetailTagTLSConfigurationError}
-	SendErrorTLSAlertReceived                  = SendErrorDetail{tag: sendErrorDetailTagTLSAlertReceived}
-	SendErrorTLSProtocolError                  = SendErrorDetail{tag: sendErrorDetailTagTLSProtocolError}
-	SendErrorHTTPIncompleteResponse            = SendErrorDetail{tag: sendErrorDetailTagHTTPIncompleteResponse}
-	SendErrorHTTPResponseHeaderSectionTooLarge = SendErrorDetail{tag: sendErrorDetailTagHTTPResponseHeaderSectionTooLarge}
-	SendErrorHTTPResponseBodyTooLarge          = SendErrorDetail{tag: sendErrorDetailTagHTTPResponseBodyTooLarge}
-	SendErrorHTTPResponseTimeout               = SendErrorDetail{tag: sendErrorDetailTagHTTPResponseTimeout}
-	SendErrorHTTPResponseStatusInvalid         = SendErrorDetail{tag: sendErrorDetailTagHTTPResponseStatusInvalid}
-	SendErrorHTTPUpgradeFailed                 = SendErrorDetail{tag: sendErrorDetailTagHTTPUpgradeFailed}
-	SendErrorHTTPProtocolError                 = SendErrorDetail{tag: sendErrorDetailTagHTTPProtocolError}
-	SendErrorHTTPRequestCacheKeyInvalid        = SendErrorDetail{tag: sendErrorDetailTagHTTPRequestCacheKeyInvalid}
-	SendErrorHTTPRequestURIInvalid             = SendErrorDetail{tag: sendErrorDetailTagHTTPRequestURIInvalid}
-	SendErrorInternalError                     = SendErrorDetail{tag: sendErrorDetailTagInternalError}
-)
+// Cause returns the specific cause of the backend request failure.
+func (d SendErrorDetail) Cause() SendErrorDetailTag {
+	return d.Tag
+}
 
 func (d SendErrorDetail) valid() bool {
-	switch d.tag {
-	case sendErrorDetailTagUninitialized:
+	switch d.Tag {
+	case SendErrorDetailTagUninitialized:
 		// Not enough information to convert to an error.  In this case,
 		// the caller should use the FastlyStatus as the basis for the
 		// error instead.
 		return false
 
-	case sendErrorDetailTagOK:
+	case SendErrorDetailTagOK:
 		// No error
 		return false
 	}
 
 	return true
-}
-
-// Is implements error comparison for use with errors.Is().
-// This allows sentinel errors to be compared against SendErrorDetail values.
-func (d SendErrorDetail) Is(target error) bool {
-	if t, ok := target.(SendErrorDetail); ok {
-		return d.tag == t.tag
-	}
-	return false
 }
 
 // DNSErrorRCode returns the DNS response code for DNS errors.
@@ -1415,61 +1384,61 @@ func (d SendErrorDetail) Error() string {
 }
 
 func (d SendErrorDetail) String() string {
-	switch d.tag {
-	case sendErrorDetailTagDNSTimeout:
+	switch d.Tag {
+	case SendErrorDetailTagDNSTimeout:
 		return "DNS timeout"
-	case sendErrorDetailTagDNSError:
+	case SendErrorDetailTagDNSError:
 		return fmt.Sprintf("DNS error (rcode=%d, info_code=%d)", d.dnsErrorRCode, d.dnsErrorInfoCode)
-	case sendErrorDetailTagDestinationNotFound:
+	case SendErrorDetailTagDestinationNotFound:
 		return "destination not found"
-	case sendErrorDetailTagDestinationUnavailable:
+	case SendErrorDetailTagDestinationUnavailable:
 		return "destination unavailable"
-	case sendErrorDetailTagDestinationIPUnroutable:
+	case SendErrorDetailTagDestinationIPUnroutable:
 		return "destination IP unroutable"
-	case sendErrorDetailTagConnectionRefused:
+	case SendErrorDetailTagConnectionRefused:
 		return "connection refused"
-	case sendErrorDetailTagConnectionTerminated:
+	case SendErrorDetailTagConnectionTerminated:
 		return "connection terminated"
-	case sendErrorDetailTagConnectionTimeout:
+	case SendErrorDetailTagConnectionTimeout:
 		return "connection timeout"
-	case sendErrorDetailTagConnectionLimitReached:
+	case SendErrorDetailTagConnectionLimitReached:
 		return "connection limit reached"
-	case sendErrorDetailTagTLSCertificateError:
+	case SendErrorDetailTagTLSCertificateError:
 		return "TLS certificate error"
-	case sendErrorDetailTagTLSConfigurationError:
+	case SendErrorDetailTagTLSConfigurationError:
 		return "TLS configuration error"
-	case sendErrorDetailTagHTTPIncompleteResponse:
+	case SendErrorDetailTagHTTPIncompleteResponse:
 		return "incomplete HTTP response"
-	case sendErrorDetailTagHTTPResponseHeaderSectionTooLarge:
+	case SendErrorDetailTagHTTPResponseHeaderSectionTooLarge:
 		return "HTTP response header section too large"
-	case sendErrorDetailTagHTTPResponseBodyTooLarge:
+	case SendErrorDetailTagHTTPResponseBodyTooLarge:
 		return "HTTP response body too large"
-	case sendErrorDetailTagHTTPResponseTimeout:
+	case SendErrorDetailTagHTTPResponseTimeout:
 		return "HTTP response timeout"
-	case sendErrorDetailTagHTTPResponseStatusInvalid:
+	case SendErrorDetailTagHTTPResponseStatusInvalid:
 		return "HTTP response status invalid"
-	case sendErrorDetailTagHTTPUpgradeFailed:
+	case SendErrorDetailTagHTTPUpgradeFailed:
 		return "HTTP upgrade failed"
-	case sendErrorDetailTagHTTPProtocolError:
+	case SendErrorDetailTagHTTPProtocolError:
 		return "HTTP protocol error"
-	case sendErrorDetailTagHTTPRequestCacheKeyInvalid:
+	case SendErrorDetailTagHTTPRequestCacheKeyInvalid:
 		return "HTTP request cache key invalid"
-	case sendErrorDetailTagHTTPRequestURIInvalid:
+	case SendErrorDetailTagHTTPRequestURIInvalid:
 		return "HTTP request URI invalid"
-	case sendErrorDetailTagInternalError:
+	case SendErrorDetailTagInternalError:
 		return "internal error"
-	case sendErrorDetailTagTLSAlertReceived:
+	case SendErrorDetailTagTLSAlertReceived:
 		return fmt.Sprintf("TLS alert received (%s)", tlsAlertString(d.tlsAlertID))
-	case sendErrorDetailTagTLSProtocolError:
+	case SendErrorDetailTagTLSProtocolError:
 		return "TLS protocol error"
 
-	case sendErrorDetailTagUninitialized:
-		panic("should not be reached: sendErrorDetailTagUninitialized")
-	case sendErrorDetailTagOK:
-		panic("should not be reached: sendErrorDetailTagOK")
+	case SendErrorDetailTagUninitialized:
+		panic("should not be reached: SendErrorDetailTagUninitialized")
+	case SendErrorDetailTagOK:
+		panic("should not be reached: SendErrorDetailTagOK")
 
 	default:
-		return fmt.Sprintf("unknown error (%d)", d.tag)
+		return fmt.Sprintf("unknown error (%d)", d.Tag)
 	}
 }
 


### PR DESCRIPTION
Rather than using sentinel errors, this adds a Cause() method to
SendError that returns a constant that callers can match against.  This
is a little less magical than using errors.Is().
