### PR TITLE
add SandboxRequests to fastlyMeta

### DIFF
--- a/_examples/reusable-sandbox/main.go
+++ b/_examples/reusable-sandbox/main.go
@@ -11,15 +11,13 @@ import (
 )
 
 func main() {
-	var requestCount int
 	fsthttp.ServeMany(func(ctx context.Context, w fsthttp.ResponseWriter, r *fsthttp.Request) {
-		requestCount++
 		meta, err := r.FastlyMeta()
 		if err != nil {
 			fsthttp.Error(w, err.Error(), fsthttp.StatusInternalServerError)
 			return
 		}
-		fmt.Fprintf(w, "Request %v, Hello, %s (sandbox: %q, request: %q)!\n", requestCount, r.RemoteAddr, meta.SandboxID, meta.RequestID)
+		fmt.Fprintf(w, "Request %v, Hello, %s (sandbox: %q, request: %q)!\n", meta.SandboxRequests, r.RemoteAddr, meta.SandboxID, meta.RequestID)
 	}, &fsthttp.ServeManyOptions{
 		NextTimeout: 1 * time.Second,
 		MaxRequests: 100,

--- a/end_to_end_tests/serve-many/main.go
+++ b/end_to_end_tests/serve-many/main.go
@@ -35,6 +35,7 @@ func main() {
 		w.Header().Set("Content-Type", "text/plain")
 		w.Header().Set("Sandbox-ID", sandboxID)
 		w.Header().Set("Request-ID", requestID)
+		w.Header().Set("Sandbox-Requests", fmt.Sprintf("%d", meta.SandboxRequests))
 		w.Write([]byte("OK"))
 	}
 

--- a/end_to_end_tests/serve-many/main_test.go
+++ b/end_to_end_tests/serve-many/main_test.go
@@ -22,12 +22,16 @@ func TestSandboxReuse(t *testing.T) {
 	defer resp.Body.Close()
 
 	sandboxID, requestID := resp.Header.Get("Sandbox-ID"), resp.Header.Get("Request-ID")
+	sandboxRequests := resp.Header.Get("Sandbox-Requests")
 
 	if sandboxID == "" || requestID == "" {
 		t.Fatalf("Sandbox-ID and/or Request-ID are empty: %s, %s", sandboxID, requestID)
 	}
 	if sandboxID != requestID {
 		t.Errorf("sandboxID = %s, requestID = %s; expected them to match", sandboxID, requestID)
+	}
+	if sandboxRequests != "1" {
+		t.Errorf("sandboxRequests = %s; expected 1", sandboxRequests)
 	}
 	prevSandboxID := sandboxID
 
@@ -49,12 +53,16 @@ func TestSandboxReuse(t *testing.T) {
 	defer resp.Body.Close()
 
 	sandboxID, requestID = resp.Header.Get("Sandbox-ID"), resp.Header.Get("Request-ID")
+	sandboxRequests = resp.Header.Get("Sandbox-Requests")
 
 	if sandboxID != prevSandboxID {
 		t.Errorf("sandboxID = %s, previous sandboxID = %s; expected them to match", sandboxID, sandboxID)
 	}
 	if sandboxID == requestID {
 		t.Errorf("sandboxID = %s, requestID = %s; expected them to differ", sandboxID, requestID)
+	}
+	if sandboxRequests != "2" {
+		t.Errorf("sandboxRequests = %s; expected 2", sandboxRequests)
 	}
 	prevSandboxID = sandboxID
 
@@ -70,11 +78,15 @@ func TestSandboxReuse(t *testing.T) {
 	defer resp.Body.Close()
 
 	sandboxID, requestID = resp.Header.Get("Sandbox-ID"), resp.Header.Get("Request-ID")
+	sandboxRequests = resp.Header.Get("Sandbox-Requests")
 
 	if sandboxID == prevSandboxID {
 		t.Errorf("sandboxID = %s, previous sandboxID = %s; expected them to differ", sandboxID, sandboxID)
 	}
 	if sandboxID != requestID {
 		t.Errorf("sandboxID = %s, requestID = %s; expected them to match", sandboxID, requestID)
+	}
+	if sandboxRequests != "1" {
+		t.Errorf("sandboxRequests = %s; expected 1", sandboxRequests)
 	}
 }


### PR DESCRIPTION
This lets handlers track how many requests have been handled
by the current sandbox.
