### PR TITLE
handle invalid 1xx status codes in client responses

### DIFF
--- a/end_to_end_tests/loopback/main.go
+++ b/end_to_end_tests/loopback/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/fastly/compute-sdk-go/fsthttp"
@@ -13,6 +14,15 @@ import (
 
 func main() {
 	handler := func(ctx context.Context, w fsthttp.ResponseWriter, r *fsthttp.Request) {
+		statusCode := 200
+		if c := r.URL.Query().Get("status_code"); c != "" {
+			var err error
+			statusCode, err = strconv.Atoi(c)
+			if err != nil {
+				panic(err)
+			}
+		}
+
 		// Verify that a bunch of function calls work, then return OK.
 		fmt.Println("Proto =", r.Proto)
 		fmt.Println("-- Headers --")
@@ -47,6 +57,7 @@ func main() {
 
 		w.Header().Set("Content-Type", "text/plain")
 		w.Header().Set("X-Test-Header", "present")
+		w.WriteHeader(statusCode)
 		w.Write([]byte("OK"))
 	}
 	fsthttp.ServeFunc(handler)

--- a/end_to_end_tests/loopback/main_test.go
+++ b/end_to_end_tests/loopback/main_test.go
@@ -62,3 +62,26 @@ func doLoopbackRequest(t *testing.T, req *fsthttp.Request) *fsthttp.Response {
 	}
 	return resp
 }
+
+func Test1xxStatusCode(t *testing.T) {
+	req, err := fsthttp.NewRequest("GET", "http://anyplace.horse?status_code=101", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := req.Send(context.Background(), "self")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	if got, want := resp.StatusCode, 500; got != want {
+		// Unlike Compute, Viceroy returns a 101 status code until
+		// https://github.com/fastly/Viceroy/pull/557 lands, probably in
+		// v0.16.1.
+		if got == 101 {
+			t.Logf("StatusCode = %d, want: %d; accepting until Viceroy is fixed", got, want)
+		} else {
+			t.Errorf("StatusCode = %d, want: %d", got, want)
+		}
+	}
+}

--- a/fsthttp/handle.go
+++ b/fsthttp/handle.go
@@ -43,6 +43,12 @@ func serve(h Handler, abireq *fastly.HTTPRequest, abibody *fastly.HTTPBody, sand
 	}
 
 	h.ServeHTTP(ctx, clientResponseWriter, clientRequest)
+
+	// If we were unable to send the response due to an error, panic and hope we sent a 500.
+	if clientResponseWriter.sendErr != nil {
+		panic(fmt.Errorf("send response downstream: %w", clientResponseWriter.sendErr))
+	}
+
 	clientResponseWriter.Close()
 }
 

--- a/internal/abi/fastly/http_guest.go
+++ b/internal/abi/fastly/http_guest.go
@@ -2218,9 +2218,7 @@ func fastlyHTTPRespHeaderValuesSet(
 	valuesData prim.Pointer[prim.U8], valuesLen prim.Usize, // multiple values separated by \0
 ) FastlyStatus
 
-// SetHeaderValues sets the provided header(s) on the response.
-//
-// TODO(pb): does this overwrite any existing name headers?
+// SetHeaderValues sets the provided header(s) on the response.  This replaces any existing values for this header.
 func (r *HTTPResponse) SetHeaderValues(name string, values []string) error {
 	var buf bytes.Buffer
 	for _, value := range values {


### PR DESCRIPTION
handle invalid 1xx status codes in client responses

Compute does not allow 1xx status codes (except 103 Early Hints) and
returns FastlyStatus::Inval from SendDownstream if it is set.  We don't
check that call for errors and that causes us to silently return an
empty 200 OK response.

Because WriteHeader is infallible, we now capture the error from
SendDownstream on the responseWriter and return it from subsequent
Write, Append, and Close calls.  For the specific case of an invalid
status code, we translate it into a new exported ErrInvalidStatusCode
error.

Because calling SendDownstream consumes the underlying ABI response and
body even in failure, this situation is unrecoverable.  serve() checks
for that SendDownstream error and panics, ensuring that clients will
receive a 500 status code rather than a 200.

The docs for WriteHeader have been updated to explain that 1xx codes
are not permitted, and describe the error behavior.