### PR TITLE
add IfGenerationMatch to kvstore.InsertConfig

### DIFF
--- a/integration_tests/kvstore/main_test.go
+++ b/integration_tests/kvstore/main_test.go
@@ -59,6 +59,33 @@ func TestKVStore(t *testing.T) {
 		t.Error("expected Lookup failure after delete")
 	}
 
+	err = store.Insert("animal", strings.NewReader("cat"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	animal, err = store.Lookup("animal")
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentGeneration := animal.Generation()
+
+	err = store.InsertWithConfig("animal", strings.NewReader("dog"), &kvstore.InsertConfig{
+		IfGenerationMatch: currentGeneration,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.InsertWithConfig("animal", strings.NewReader("dog"), &kvstore.InsertConfig{
+		IfGenerationMatch: currentGeneration,
+	})
+	if err == nil {
+		t.Error("expected InsertWithConfig failure due to generation mismatch")
+	}
+	err = store.Delete("animal")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	/*
 		// TODO(athomason) address inconsistent behavior in viceroy and production
 		if err = store.Delete("nonexistent"); err != nil {

--- a/kvstore/kvstore.go
+++ b/kvstore/kvstore.go
@@ -151,10 +151,11 @@ const (
 )
 
 type InsertConfig struct {
-	Mode            InsertMode
-	BackgroundFetch bool
-	Metadata        []byte
-	TTLSec          uint32
+	Mode              InsertMode
+	BackgroundFetch   bool
+	Metadata          []byte
+	TTLSec            uint32
+	IfGenerationMatch uint64
 }
 
 // Insert adds a key to the associated KV store.
@@ -170,6 +171,9 @@ func (s *Store) InsertWithConfig(key string, value io.Reader, config *InsertConf
 		}
 		if config.TTLSec != 0 {
 			abiConf.TTLSec(config.TTLSec)
+		}
+		if config.IfGenerationMatch != 0 {
+			abiConf.IfGenerationMatch(config.IfGenerationMatch)
 		}
 	}
 


### PR DESCRIPTION
I noticed that `if-generation-match` is supported internally but not exposed in the public `kvstore.InsertConfig`. Since it's a small change (just a few lines), I've opened this PR. This is my first contribution here—please let me know if I missed any conventions!