### PR TITLE
resvpnproxy: Add Available field

### DIFF
--- a/_examples/resvpnproxy/main.go
+++ b/_examples/resvpnproxy/main.go
@@ -41,6 +41,14 @@ func main() {
 			return
 		}
 
+		// Check to see if we have live data by checking Available. It doesn't make sense ingesting the rest of the
+		// response if available is false.
+		if !vpnData.Available {
+			w.WriteHeader(fsthttp.StatusOK)
+			fmt.Fprintf(w, `{"error": "ResVPNProxy dataset not enabled for this service"}`)
+			return
+		}
+
 		// Success case - return the ResVPNProxy data
 		w.WriteHeader(fsthttp.StatusOK)
 		response := Response{

--- a/fsthttp/resvpnproxy.go
+++ b/fsthttp/resvpnproxy.go
@@ -2,10 +2,13 @@ package fsthttp
 
 import (
 	"fmt"
+
+	"github.com/fastly/compute-sdk-go/internal/abi/fastly"
 )
 
 // ResVPNProxyResult represents additional IP Proxy and VPN Intelligence data for a request.
 type ResVPNProxyResult struct {
+	Available          bool   `json:"available"`            // True if the proxy/vpn intelligence dataset is enabled for the service.
 	IsAnonymous        bool   `json:"is_anonymous"`         // True if the IP address is present in one or more categories of anonymous flags.
 	IsAnonymousVPN     bool   `json:"is_anonymous_vpn"`     // True if the IP address was identified as being from a Virtual Private Network (VPN) exit node.
 	IsHostingProvider  bool   `json:"is_hosting_provider"`  // True if the IP address was identified as being from a hosting provider or data center.
@@ -21,13 +24,12 @@ type ResVPNProxyResult struct {
 
 // ResVPNProxyData analyzes the current downstream request's IP address and returns VPN and proxy intelligence data.
 //
-// Returns an error if the ResVPNProxy feature is not enabled for your service or intelligence data is not available.
+// Response will return the field "Available" as false if the ResVPNProxy dataset is not enabled for the service.
 //
 // Example usage:
 //
 //	vpnData, err := r.ResVPNProxyData()
 //	if err != nil {
-//	    // Feature not enabled or other error
 //	    return err
 //	}
 func (r *Request) ResVPNProxyData() (*ResVPNProxyResult, error) {
@@ -35,61 +37,72 @@ func (r *Request) ResVPNProxyData() (*ResVPNProxyResult, error) {
 		return nil, fmt.Errorf("downstream request not available")
 	}
 
-	result := &ResVPNProxyResult{}
+	result := &ResVPNProxyResult{
+		Available: true,
+	}
 	var err error
 
 	result.IsAnonymous, err = r.downstream.req.DownstreamResVPNProxyIsAnonymous()
-	if err = ignoreNoneError(err); err != nil {
+	// For the very first check we check to see if we have a `FastlyStatusNone` error. This indicates whether the
+	// dataset is enabled or not. We communicate this to the user by passing back an empty struct which should
+	// default to `false` for the `Available` field.
+	//
+	// For any future calls after this, it should be impossible to get a FastlyStatusNone and therefore this first
+	// call is the only place where we should have to do this check.
+	if err != nil {
+		if status, ok := fastly.IsFastlyError(err); ok && status == fastly.FastlyStatusNone {
+			return &ResVPNProxyResult{}, nil
+		}
 		return nil, fmt.Errorf("is_anonymous: %w", err)
 	}
 
 	result.IsAnonymousVPN, err = r.downstream.req.DownstreamResVPNProxyIsAnonymousVPN()
-	if err = ignoreNoneError(err); err != nil {
+	if err != nil {
 		return nil, fmt.Errorf("is_anonymous_vpn: %w", err)
 	}
 
 	result.IsHostingProvider, err = r.downstream.req.DownstreamResVPNProxyIsHostingProvider()
-	if err = ignoreNoneError(err); err != nil {
+	if err != nil {
 		return nil, fmt.Errorf("is_hosting_provider: %w", err)
 	}
 
 	result.IsProxyOverVPN, err = r.downstream.req.DownstreamResVPNProxyIsProxyOverVPN()
-	if err = ignoreNoneError(err); err != nil {
+	if err != nil {
 		return nil, fmt.Errorf("is_proxy_over_vpn: %w", err)
 	}
 
 	result.IsPublicProxy, err = r.downstream.req.DownstreamResVPNProxyIsPublicProxy()
-	if err = ignoreNoneError(err); err != nil {
+	if err != nil {
 		return nil, fmt.Errorf("is_public_proxy: %w", err)
 	}
 
 	result.IsRelayProxy, err = r.downstream.req.DownstreamResVPNProxyIsRelayProxy()
-	if err = ignoreNoneError(err); err != nil {
+	if err != nil {
 		return nil, fmt.Errorf("is_relay_proxy: %w", err)
 	}
 
 	result.IsResidentialProxy, err = r.downstream.req.DownstreamResVPNProxyIsResidentialProxy()
-	if err = ignoreNoneError(err); err != nil {
+	if err != nil {
 		return nil, fmt.Errorf("is_residential_proxy: %w", err)
 	}
 
 	result.IsSmartDNSProxy, err = r.downstream.req.DownstreamResVPNProxyIsSmartDNSProxy()
-	if err = ignoreNoneError(err); err != nil {
+	if err != nil {
 		return nil, fmt.Errorf("is_smart_dns_proxy: %w", err)
 	}
 
 	result.IsTorExitNode, err = r.downstream.req.DownstreamResVPNProxyIsTorExitNode()
-	if err = ignoreNoneError(err); err != nil {
+	if err != nil {
 		return nil, fmt.Errorf("is_tor_exit_node: %w", err)
 	}
 
 	result.IsVPNDatacenter, err = r.downstream.req.DownstreamResVPNProxyIsVPNDatacenter()
-	if err = ignoreNoneError(err); err != nil {
+	if err != nil {
 		return nil, fmt.Errorf("is_vpn_datacenter: %w", err)
 	}
 
 	result.VPNServiceName, err = r.downstream.req.DownstreamResVPNProxyVPNServiceName()
-	if err = ignoreNoneError(err); err != nil {
+	if err != nil {
 		return nil, fmt.Errorf("vpn_service_name: %w", err)
 	}
 


### PR DESCRIPTION
This adds an "Available" field to the response back from resvpnproxy.

Previously I left this field out due to time constraints and because I was unconvinced that it was the best way to communicate to the user the fact that the dataset might not be enabled and that is why the rest of the fields have defaults. I had considered it being a separate, informative error instead might be clearer to the user and can be easily ignored as well.

I remain unconvinced, but since `Available` is part of the spec and docs that decision point has flown.

Tested on https://resvpnproxy-compute-lookup.edgecompute.app

```
~❯ curl -s "https://resvpnproxy-compute-lookup.edgecompute.app/resvpnproxy" | jq
{
  "client_ip": "1.1.1.1",
  "available": true,
  "is_anonymous": false,
  "is_anonymous_vpn": false,
  "is_hosting_provider": false,
  "is_proxy_over_vpn": false,
  "is_public_proxy": false,
  "is_relay_proxy": false,
  "is_residential_proxy": false,
  "is_smart_dns_proxy": false,
  "is_tor_exit_node": false,
  "is_vpn_datacenter": false,
  "vpn_service_name": ""
}
```