### PR TITLE
kvstore: Enhance KVStore InsertWithConfig integration tests

### DIFF
--- a/integration_tests/kvstore/main_test.go
+++ b/integration_tests/kvstore/main_test.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"maps"
 	"sort"
 	"strconv"
@@ -183,7 +184,105 @@ func TestKVStoreInsertWithConfig(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-	t.Run("Mode", func(t *testing.T) {})
+	t.Run("Mode/Overwrite", func(t *testing.T) {
+		err := store.InsertWithConfig("overwritekey", strings.NewReader("v"), &kvstore.InsertConfig{
+			Mode: kvstore.InsertModeOverwrite,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = store.InsertWithConfig("overwritekey", strings.NewReader("updated"), &kvstore.InsertConfig{
+			Mode: kvstore.InsertModeOverwrite,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		entry, err := store.Lookup("overwritekey")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := entry.String(); got != "updated" {
+			t.Errorf("Overwrite mode: got %q, want 'updated'", got)
+		}
+		err = store.Delete("overwritekey")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("Mode/Add", func(t *testing.T) {
+		err := store.InsertWithConfig("addkey", strings.NewReader("v"), &kvstore.InsertConfig{
+			Mode: kvstore.InsertModeAdd,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = store.InsertWithConfig("addkey", strings.NewReader("updated"), &kvstore.InsertConfig{
+			Mode: kvstore.InsertModeAdd,
+		})
+		if err == nil {
+			t.Errorf("Add mode: expected error when adding existing key, got nil")
+		}
+		if !errors.Is(err, kvstore.ErrPreconditionFailed) {
+			t.Errorf("Add mode: expected ErrPreconditionFailed, got %v", err)
+		}
+		entry, err := store.Lookup("addkey")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := entry.String(); got != "v" {
+			t.Errorf("Add mode: got %q, want 'v'", got)
+		}
+		err = store.Delete("addkey")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("Mode/Append", func(t *testing.T) {
+		err := store.Insert("appendkey", strings.NewReader("1"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = store.InsertWithConfig("appendkey", strings.NewReader("2"), &kvstore.InsertConfig{
+			Mode: kvstore.InsertModeAppend,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		entry, err := store.Lookup("appendkey")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := entry.String(); got != "12" {
+			t.Errorf("Append mode: got %q, want '12'", got)
+		}
+		err = store.Delete("appendkey")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("Mode/Prepend", func(t *testing.T) {
+		err := store.Insert("prependkey", strings.NewReader("2"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = store.InsertWithConfig("prependkey", strings.NewReader("1"), &kvstore.InsertConfig{
+			Mode: kvstore.InsertModePrepend,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		entry, err := store.Lookup("prependkey")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := entry.String(); got != "12" {
+			t.Errorf("Prepend mode: got %q, want '12'", got)
+		}
+		err = store.Delete("prependkey")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 	t.Run("AcceptsAllFields", func(t *testing.T) {
 		err := store.InsertWithConfig("allfields", strings.NewReader("v"), &kvstore.InsertConfig{
 			Mode:            kvstore.InsertModeOverwrite,

--- a/integration_tests/kvstore/main_test.go
+++ b/integration_tests/kvstore/main_test.go
@@ -163,7 +163,26 @@ func TestKVStoreInsertWithConfig(t *testing.T) {
 			t.Fatal(err)
 		}
 	})
-	t.Run("Metadata", func(t *testing.T) {})
+	t.Run("Metadata", func(t *testing.T) {
+		err := store.InsertWithConfig("animal", strings.NewReader("cat"), &kvstore.InsertConfig{
+			Metadata: []byte("metadata"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		animal, err := store.Lookup("animal")
+		if err != nil {
+			t.Fatal(err)
+		}
+		metadata := animal.Meta()
+		if string(metadata) != "metadata" {
+			t.Errorf("expected metadata to be 'metadata', got %q", string(metadata))
+		}
+		err = store.Delete("animal")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 	t.Run("Mode", func(t *testing.T) {})
 	t.Run("Configs", func(t *testing.T) {})
 }

--- a/integration_tests/kvstore/main_test.go
+++ b/integration_tests/kvstore/main_test.go
@@ -59,33 +59,6 @@ func TestKVStore(t *testing.T) {
 		t.Error("expected Lookup failure after delete")
 	}
 
-	err = store.Insert("animal", strings.NewReader("cat"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	animal, err = store.Lookup("animal")
-	if err != nil {
-		t.Fatal(err)
-	}
-	currentGeneration := animal.Generation()
-
-	err = store.InsertWithConfig("animal", strings.NewReader("dog"), &kvstore.InsertConfig{
-		IfGenerationMatch: currentGeneration,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	err = store.InsertWithConfig("animal", strings.NewReader("dog"), &kvstore.InsertConfig{
-		IfGenerationMatch: currentGeneration,
-	})
-	if err == nil {
-		t.Error("expected InsertWithConfig failure due to generation mismatch")
-	}
-	err = store.Delete("animal")
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	/*
 		// TODO(athomason) address inconsistent behavior in viceroy and production
 		if err = store.Delete("nonexistent"); err != nil {
@@ -155,6 +128,44 @@ func TestKVStore(t *testing.T) {
 	if got, want := hello.String(), "hello, world"; got != want {
 		t.Errorf("HTTPBody Lookup: got %q, want %q", got, want)
 	}
+}
+
+func TestKVStoreInsertWithConfig(t *testing.T) {
+	store, err := kvstore.Open("example-test-kv-store")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Run("IfGenerationMatch", func(t *testing.T) {
+		err := store.Insert("animal", strings.NewReader("cat"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		animal, err := store.Lookup("animal")
+		if err != nil {
+			t.Fatal(err)
+		}
+		currentGeneration := animal.Generation()
+
+		err = store.InsertWithConfig("animal", strings.NewReader("dog"), &kvstore.InsertConfig{
+			IfGenerationMatch: currentGeneration,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = store.InsertWithConfig("animal", strings.NewReader("dog"), &kvstore.InsertConfig{
+			IfGenerationMatch: currentGeneration,
+		})
+		if err == nil {
+			t.Error("expected failure due to generation mismatch")
+		}
+		err = store.Delete("animal")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+	t.Run("Metadata", func(t *testing.T) {})
+	t.Run("Mode", func(t *testing.T) {})
+	t.Run("Configs", func(t *testing.T) {})
 }
 
 func mapKeys(m map[string]bool) []string {

--- a/integration_tests/kvstore/main_test.go
+++ b/integration_tests/kvstore/main_test.go
@@ -184,7 +184,21 @@ func TestKVStoreInsertWithConfig(t *testing.T) {
 		}
 	})
 	t.Run("Mode", func(t *testing.T) {})
-	t.Run("Configs", func(t *testing.T) {})
+	t.Run("AcceptsAllFields", func(t *testing.T) {
+		err := store.InsertWithConfig("allfields", strings.NewReader("v"), &kvstore.InsertConfig{
+			Mode:            kvstore.InsertModeOverwrite,
+			BackgroundFetch: true,
+			TTLSec:          3600,
+			Metadata:        []byte("meta"),
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = store.Delete("allfields")
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
 }
 
 func mapKeys(m map[string]bool) []string {


### PR DESCRIPTION
Expand and refactor KV store integration tests for InsertWithConfig to improve coverage and clarify behavior.

- Move/refactor IfGenerationMatch assertions into TestKVStoreInsertWithConfig
- Add the others fields tests

I've moved the InsertWithConfig tests into a separate function to keep TestKVStore from getting too bloated and to improve readability.

```golang
func TestKVStoreInsertWithConfig(t *testing.T) {
	t.Run("IfGenerationMatch", func(t *testing.T) {
	})
	t.Run("Metadata", func(t *testing.T) {
	})
	t.Run("Mode/Overwrite", func(t *testing.T) {
	})
	t.Run("Mode/Add", func(t *testing.T) {
	})
	t.Run("Mode/Append", func(t *testing.T) {
	})
	t.Run("Mode/Prepend", func(t *testing.T) {
	})
	t.Run("AcceptsAllFields", func(t *testing.T) {
	})
}
```
