### PR TITLE
Support `nil` BackendOptions param in RegisterDynamicBackend

### DIFF
--- a/fsthttp/backend.go
+++ b/fsthttp/backend.go
@@ -441,7 +441,7 @@ func (b *BackendOptions) UseGRPC(v bool) *BackendOptions {
 	return b
 }
 
-// Register a new dynamic backend.
+// RegisterDynamicBackend registers a new dynamic backend.
 func RegisterDynamicBackend(name string, target string, options *BackendOptions) (*Backend, error) {
 	var abiOpts *fastly.BackendConfigOptions
 	if options != nil {
@@ -450,7 +450,7 @@ func RegisterDynamicBackend(name string, target string, options *BackendOptions)
 		abiOpts = &fastly.BackendConfigOptions{}
 	}
 
-	if len(options.err) > 0 {
+	if options != nil && len(options.err) > 0 {
 		return nil, errors.Join(options.err...)
 	}
 

--- a/integration_tests/backend/main_test.go
+++ b/integration_tests/backend/main_test.go
@@ -100,12 +100,49 @@ func TestDynamicBackend(t *testing.T) {
 	}
 }
 
+func TestDynamicBackendNilOptions(t *testing.T) {
+	handler := func(ctx context.Context, w fsthttp.ResponseWriter, r *fsthttp.Request) {
+		b, err := fsthttp.RegisterDynamicBackend(
+			"dynamic-nil-opts",
+			"compute-sdk-test-backend.edgecompute.app",
+			nil,
+		)
+		if err != nil {
+			t.Errorf("RegisterDynamicBackend: %v", err)
+			fsthttp.Error(w, err.Error(), fsthttp.StatusInternalServerError)
+			return
+		}
+
+		if got, want := b.IsDynamic(), true; got != want {
+			t.Errorf("IsDynamic() = %v, want %v", got, want)
+			fsthttp.Error(w, "IsDynamic mismatch", fsthttp.StatusInternalServerError)
+			return
+		}
+
+		fmt.Fprint(w, "Ok")
+	}
+
+	r, err := fsthttp.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	w := fsttest.NewRecorder()
+
+	handler(context.Background(), w, r)
+
+	if got, want := w.Code, fsthttp.StatusOK; got != want {
+		t.Errorf("Code = %d, want %d", got, want)
+	}
+
+	if got, want := w.Body.String(), "Ok"; got != want {
+		t.Errorf("Body = %q, want %q", got, want)
+	}
+}
+
 func TestOriginHealth(t *testing.T) {
 	handler := func(ctx context.Context, w fsthttp.ResponseWriter, r *fsthttp.Request) {
-
 		{
 			b, err := fsthttp.BackendFromName("healthy")
-
 			if err != nil {
 				t.Errorf("BackendFromName: %v", err)
 				fsthttp.Error(w, err.Error(), fsthttp.StatusInternalServerError)
@@ -129,7 +166,6 @@ func TestOriginHealth(t *testing.T) {
 		}
 
 		b, err := fsthttp.BackendFromName("unhealthy")
-
 		if err != nil {
 			t.Errorf("BackendFromName: %v", err)
 			fsthttp.Error(w, err.Error(), fsthttp.StatusInternalServerError)


### PR DESCRIPTION
This function already had a nil check for `options`, so it seems like the intent was to support nil. This covers the other case where it needs to be checked for nil before accessing.