### PR TITLE
kvstore: Enhance InsertWithConfig test for IfGenerationMatch behavior

### DIFF
--- a/integration_tests/kvstore/main_test.go
+++ b/integration_tests/kvstore/main_test.go
@@ -153,12 +153,32 @@ func TestKVStoreInsertWithConfig(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		err = store.InsertWithConfig("animal", strings.NewReader("dog"), &kvstore.InsertConfig{
+		animal, err = store.Lookup("animal")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := animal.String(); got != "dog" {
+			t.Errorf("expected value to be 'dog', got %q", got)
+		}
+
+		err = store.InsertWithConfig("animal", strings.NewReader("monkey"), &kvstore.InsertConfig{
 			IfGenerationMatch: currentGeneration,
 		})
 		if err == nil {
 			t.Error("expected failure due to generation mismatch")
 		}
+		if !errors.Is(err, kvstore.ErrPreconditionFailed) {
+			t.Errorf("expected ErrPreconditionFailed, got %v", err)
+		}
+
+		animal, err = store.Lookup("animal")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := animal.String(); got != "dog" {
+			t.Errorf("expected value to still be 'dog', got %q", got)
+		}
+
 		err = store.Delete("animal")
 		if err != nil {
 			t.Fatal(err)


### PR DESCRIPTION
checking the value after both successful and failed updates

- `cat` (Init)
- `dog` (Valid match) ➡️ Update successful & verify value is `dog`
- `monkey` (Invalid match) ➡️ Expect `ErrPreconditionFailed` & verify value remains `dog`



https://github.com/fastly/compute-sdk-go/pull/253#discussion_r3267381075