### PR TITLE
fix(imageopto): correct contrast URL parameter spelling

### DIFF
--- a/fsthttp/imageopto/imageopto.go
+++ b/fsthttp/imageopto/imageopto.go
@@ -881,7 +881,7 @@ func (o *Options) QueryString() (string, error) {
 	}
 
 	if o.Contrast != 0 {
-		args = append(args, "constrast="+strconv.Itoa(o.Contrast))
+		args = append(args, "contrast="+strconv.Itoa(o.Contrast))
 	}
 
 	if o.Crop != nil {

--- a/fsthttp/imageopto/imageopto_test.go
+++ b/fsthttp/imageopto/imageopto_test.go
@@ -16,7 +16,7 @@ func TestOpts(t *testing.T) {
 		{&Options{Region: RegionUsEast, Blur: NewBlurModePercentage(0.8)}, "region=us_east&blur=0.8p"},
 		{&Options{Region: RegionUsEast, Brightness: -50}, "region=us_east&brightness=-50"},
 		{&Options{Region: RegionUsEast, Bw: NewBWModeThreshold(10)}, "region=us_east&bw=threshold,10"},
-		{&Options{Region: RegionUsEast, Contrast: -5}, "region=us_east&constrast=-5"},
+		{&Options{Region: RegionUsEast, Contrast: -5}, "region=us_east&contrast=-5"},
 		{&Options{Region: RegionUsEast, Dpr: 3.2}, "region=us_east&dpr=3.2"},
 		{&Options{Region: RegionUsEast, Enable: EnableOptUpscale}, "region=us_east&enable=upscale"},
 		{&Options{Region: RegionUsEast, Format: FormatJPEGXL}, "region=us_east&format=jpegxl"},


### PR DESCRIPTION
## Summary

Closes #258. The `Contrast` option in `fsthttp/imageopto/imageopto.go:884` was building URLs with `constrast=<value>` instead of `contrast=<value>`. Per Fastly's Image Optimizer reference (https://www.fastly.com/documentation/reference/io/contrast/), the parameter is spelled `contrast`. The typo meant any user setting `Options{Contrast: ...}` was silently sending an unknown query parameter that Image Optimizer ignored, so the SDK option has effectively been a no-op since it was introduced.

## Why this matters

The reporter noticed it via inspection on line 884. I confirmed against the official IO reference - the canonical parameter name is `contrast`, not `constrast`. The existing test on `imageopto_test.go:19` was locked to the typo'd output, so the test passing didn't catch that the actual contrast adjustment never reached IO at runtime. Fixing the typo activates the feature that was already documented as supported.

## Changes

- `fsthttp/imageopto/imageopto.go:884` - `constrast=` -> `contrast=`
- `fsthttp/imageopto/imageopto_test.go:19` - matching expected-URL fixture updated to `contrast=-5`

No public Go API change (`Options.Contrast` field name is unchanged). The behavior change is that the parameter now actually reaches the IO service.

## How to test

```
$ go test ./fsthttp/imageopto/...
ok  	github.com/fastly/compute-sdk-go/fsthttp/imageopto	0.284s
$ go build ./...
$ grep -rn constrast --include='*.go' --include='*.md' .
(empty)
```

Fixes #258

AI-assisted.
