### PR TITLE
Return descriptive error when fanout is not enabled

### DIFF
--- a/fsthttp/request.go
+++ b/fsthttp/request.go
@@ -1233,9 +1233,10 @@ func (r *Request) HandoffFanout(backend string) error {
 		return ErrHandoffNotSupported
 	}
 	err := r.downstream.req.HandoffFanout(backend)
-	status, ok := fastly.IsFastlyError(err)
-	if ok && status == fastly.FastlyStatusUnsupported {
-		return ErrFanoutNotEnabled
+	if err != nil {
+		if status, ok := fastly.IsFastlyError(err); ok && status == fastly.FastlyStatusUnsupported {
+			return ErrFanoutNotEnabled
+		}
 	}
 	return err
 }

--- a/fsthttp/request.go
+++ b/fsthttp/request.go
@@ -1197,6 +1197,8 @@ type DecompressResponseOptions struct {
 
 var ErrHandoffNotSupported = errors.New("handoff not supported on this request")
 
+var ErrFanoutNotEnabled = errors.New("Fanout or WebSockets are not enabled on this service; please contact support for help")
+
 // HandoffWebsocket passes the WebSocket directly to a backend.
 //
 // This can only be used on services that have the WebSockets feature
@@ -1209,7 +1211,12 @@ func (r *Request) HandoffWebsocket(backend string) error {
 	if r.downstream.req == nil {
 		return ErrHandoffNotSupported
 	}
-	return r.downstream.req.HandoffWebsocket(backend)
+	err := r.downstream.req.HandoffWebsocket(backend)
+	status, ok := fastly.IsFastlyError(err)
+	if ok && status == fastly.FastlyStatusUnsupported {
+		return ErrFanoutNotEnabled
+	}
+	return err
 }
 
 // HandoffFanout passes the request through the Fanout GRIP proxy and on to
@@ -1224,7 +1231,12 @@ func (r *Request) HandoffFanout(backend string) error {
 	if r.downstream.req == nil {
 		return ErrHandoffNotSupported
 	}
-	return r.downstream.req.HandoffFanout(backend)
+	err := r.downstream.req.HandoffFanout(backend)
+	status, ok := fastly.IsFastlyError(err)
+	if ok && status == fastly.FastlyStatusUnsupported {
+		return ErrFanoutNotEnabled
+	}
+	return err
 }
 
 type InspectOptions struct {

--- a/fsthttp/request.go
+++ b/fsthttp/request.go
@@ -1197,7 +1197,7 @@ type DecompressResponseOptions struct {
 
 var ErrHandoffNotSupported = errors.New("handoff not supported on this request")
 
-var ErrFanoutNotEnabled = errors.New("Fanout or WebSockets are not enabled on this service; please contact support for help")
+var ErrFanoutNotEnabled = errors.New("fanout or websockets are not enabled on this service; please contact support for help")
 
 // HandoffWebsocket passes the WebSocket directly to a backend.
 //

--- a/fsthttp/request.go
+++ b/fsthttp/request.go
@@ -1212,9 +1212,10 @@ func (r *Request) HandoffWebsocket(backend string) error {
 		return ErrHandoffNotSupported
 	}
 	err := r.downstream.req.HandoffWebsocket(backend)
-	status, ok := fastly.IsFastlyError(err)
-	if ok && status == fastly.FastlyStatusUnsupported {
-		return ErrFanoutNotEnabled
+	if err != nil {
+		if status, ok := fastly.IsFastlyError(err); ok && status == fastly.FastlyStatusUnsupported {
+			return ErrFanoutNotEnabled
+		}
 	}
 	return err
 }


### PR DESCRIPTION
# Summary
Adds ErrFanoutNotEnabled to surface a descriptive error when HandoffFanout() or HandoffWebsocket() is called on a service without fanout enabled.

Checks FastlyStatus::Unsupported via IsFastlyError() in both call sites in the fsthttp package.

# Context
Previously these calls returned a generic error which was confusing for consumers. Now users get a clear message: "Fanout or WebSockets are not enabled on this service; please contact support for help."
