### PR TITLE
fsthttp: allow excluding net/http if not required

### DIFF
--- a/fsthttp/adapter.go
+++ b/fsthttp/adapter.go
@@ -1,3 +1,5 @@
+//go:build !fastlynonethttp
+
 package fsthttp
 
 import (

--- a/fsthttp/adapter_test.go
+++ b/fsthttp/adapter_test.go
@@ -1,3 +1,5 @@
+//go:build !fastlynonethttp
+
 // This test file is in its own test package to avoid a circular
 // dependency between fsthttp and fsttest.
 

--- a/fsthttp/transport.go
+++ b/fsthttp/transport.go
@@ -1,3 +1,5 @@
+//go:build !fastlynonethttp
+
 package fsthttp
 
 import (


### PR DESCRIPTION
This also drops heap usage for a hello world from 524KB to 394KB (tinygo) and from 5.2MB to 4.2MB on Big Go.

Not sure if we should actually update the build tag to exclude by default.   Maybe exclusion is opt-in for now, but when we break the API (wasip3 / wasi-http ) we can make users opt-in to needing net/http support?

Update: this also drops request latency on for a hello world on viceroy from 2-3ms to ~1ms or less for binaries built with tinygo.  No latency difference for Big Go binaries.

Fixes #31 