### PR TITLE
.github/workflows/test: make sure other tools run for wasip1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,10 +34,14 @@ jobs:
           GOOS=wasip1 GOARCH=wasm staticcheck -tags=fastlyinternaldebug ./...
 
       - name: nilness
-        run: go tool -modfile=tools.mod nilness ./...
+        run: |
+          go install -modfile=tools.mod golang.org/x/tools/go/analysis/passes/nilness/cmd/nilness
+          GOOS=wasip1 GOARCH=wasm go vet -tags fastlyinternaldebug -vettool $(which nilness) ./...
 
       - name: ineffassign
-        run: go tool -modfile=tools.mod ineffassign ./...
+        run: |
+          go install -modfile=tools.mod github.com/gordonklaus/ineffassign
+          GOOS=wasip1 GOARCH=wasm ineffassign ./...
 
   test:
     runs-on: ubuntu-latest

--- a/integration_tests/byte_repeater/main_test.go
+++ b/integration_tests/byte_repeater/main_test.go
@@ -7,6 +7,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"errors"
 	"io"
 	"testing"
 
@@ -37,9 +38,9 @@ func TestByteRepeater(t *testing.T) {
 			switch {
 			case err == nil: // normal case
 				w.Write([]byte{b, b})
-			case err == io.EOF: // done
+			case errors.Is(err, io.EOF): // done
 				return
-			case err != nil: // error
+			default:
 				fsthttp.Error(w, fsthttp.StatusText(fsthttp.StatusBadGateway), fsthttp.StatusBadGateway)
 				t.Errorf("ReadByte: %v", err)
 				return


### PR DESCRIPTION
This lets us catch issues in the hostcall wrappers, which would otherwise be ignored.