### PR TITLE
fsthttp: expose SendErrorDetailTag so it can be used in helpers

### DIFF
--- a/fsthttp/senderror.go
+++ b/fsthttp/senderror.go
@@ -32,6 +32,7 @@ import (
 //	    }
 //	}
 type SendError = fastly.SendErrorDetail
+type SendErrorTag = fastly.SendErrorDetailTag
 
 const (
 	// SendErrorDNSTimeout indicates the system encountered a timeout when trying to

--- a/fsthttp/senderror_test.go
+++ b/fsthttp/senderror_test.go
@@ -27,7 +27,12 @@ func TestSendErrorWrapped(t *testing.T) {
 		t.Fatal("errors.As() failed to extract SendError")
 	}
 
-	if serr.Cause() != SendErrorConnectionTimeout {
-		t.Errorf("Cause() = %v, want %v", serr.Cause(), SendErrorConnectionTimeout)
+	checkCause(t, serr, SendErrorConnectionTimeout)
+}
+
+func checkCause(t *testing.T, serr SendError, want SendErrorTag) {
+	t.Helper()
+	if serr.Cause() != want {
+		t.Errorf("Cause() = %v, want %v", serr.Cause(), want)
 	}
 }


### PR DESCRIPTION
Fixes #294